### PR TITLE
Feat/create supplier from learning centre

### DIFF
--- a/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.json
+++ b/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.json
@@ -602,10 +602,10 @@
   },
   {
    "fieldname": "donor",
-   "fieldtype": "Link",
+   "fieldtype": "Table MultiSelect",
    "label": "Donor",
    "no_copy": 1,
-   "options": "Donor",
+   "options": "Donor Table",
    "read_only_depends_on": "frm.doc.status !== \"Replacement Pending\""
   },
   {
@@ -788,7 +788,7 @@
    "link_fieldname": "beneficiary"
   }
  ],
- "modified": "2025-03-17 16:24:20.113345",
+ "modified": "2025-05-14 19:43:05.923706",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Beneficiary",
@@ -907,6 +907,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "age,zone,ward,habitation",
  "show_title_field_in_link": 1,
  "sort_field": "modified",

--- a/changemakers/frappe_changemakers/doctype/learning_centre/learning_centre.py
+++ b/changemakers/frappe_changemakers/doctype/learning_centre/learning_centre.py
@@ -18,3 +18,25 @@ class LearningCentre(Document):
 
         if len(str(self.pin_code)) != 6:
             frappe.throw("Pin Code should be a numeric value with exactly 6 digits")
+
+    def after_insert(self):
+        self.create_supplier()
+        
+        
+    def create_supplier(self):
+        if not frappe.db.exists("Supplier Group", "Learning Centre"):
+            supplier_group = frappe.new_doc("Supplier Group")
+            supplier_group.supplier_group_name = "Learning Centre"
+            supplier_group.flags.ignore_permissions = True
+            supplier_group.insert()
+
+        if frappe.db.exists("Supplier", self.name):
+            return
+
+        supplier = frappe.new_doc("Supplier")
+        supplier.supplier_name = self.name
+        supplier.supplier_type = "Company"
+        supplier.supplier_group = "Learning Centre"
+
+        supplier.flags.ignore_permissions = True
+        supplier.insert()

--- a/changemakers/hooks.py
+++ b/changemakers/hooks.py
@@ -7,6 +7,7 @@ app_description = "Empowering the people that do good."
 app_email = "hussain@frappe.io"
 app_license = "AGPL"
 
+required_apps = ["erpnext", "education", "non_profit"]
 
 fixtures = [
     "Custom HTML Block",
@@ -78,7 +79,7 @@ website_route_rules = [
 # webform_include_css = {"doctype": "public/css/doctype.css"}
 
 # include js in page
-# page_js = {"page" : "public/js/file.js"}
+# page_js = {"page" : "public/js/file.js"} 
 
 # include js in doctype views
 doctype_js = {


### PR DESCRIPTION
This pull request introduces updates to the `Beneficiary` and `Learning Centre` doctypes, as well as configuration changes in `hooks.py`. The most significant changes include updating the `donor` field in the `Beneficiary` doctype, adding methods to automate supplier creation in the `Learning Centre` doctype, and specifying required apps in the `hooks.py` file.

### Updates to `Beneficiary` doctype:

* Changed the `donor` field's type from `Link` to `Table MultiSelect` and updated its options to "Donor Table" to support multiple donor selections.
* Added a new `row_format` property with the value "Dynamic" to enable dynamic row formatting.

### Enhancements to `Learning Centre` doctype:

* Added an `after_insert` method to automatically create a supplier after a new Learning Centre is added. This includes a helper method, `create_supplier`, which ensures that a "Learning Centre" supplier group exists and creates a supplier linked to the Learning Centre.

### Configuration changes:

* Added `required_apps` to `hooks.py` to specify dependencies on "erpnext," "education," and "non_profit" apps.