### PR TITLE
feat: Add custom state filtering functionality to Project doctype

### DIFF
--- a/changemakers/frappe_changemakers/overrides/project.js
+++ b/changemakers/frappe_changemakers/overrides/project.js
@@ -1,0 +1,68 @@
+frappe.ui.form.on("Project", {
+	refresh: function (frm) {
+		setup_state_filter(frm);
+	},
+
+	custom_project_countrys: function (frm) {
+		filter_states_by_selected_countries(frm);
+	},
+});
+
+function setup_state_filter(frm) {
+	let states_field = frm.fields_dict.custom_states;
+
+	states_field.get_query = function () {
+		let selected_countries = (frm.doc.custom_project_countrys || []).map(
+			(d) => d.country
+		);
+
+		if (selected_countries.length > 0) {
+			return {
+				filters: {
+					country: ["in", selected_countries],
+				},
+			};
+		} else {
+			return {};
+		}
+	};
+}
+
+function filter_states_by_selected_countries(frm) {
+	if (frm.fields_dict.custom_states) {
+		frm.fields_dict.custom_states.refresh();
+	}
+
+	let selected_states = frm.doc.custom_states || [];
+	let selected_country_names = (frm.doc.custom_project_countrys || []).map(
+		(d) => d.country
+	);
+
+	if (selected_states.length > 0 && selected_country_names.length > 0) {
+		frappe.call({
+			method: "frappe.client.get_list",
+			args: {
+				doctype: "State",
+				filters: {
+					name: ["in", selected_states.map((d) => d.state)],
+					country: ["not in", selected_country_names],
+				},
+				fields: ["name"],
+			},
+			callback: function (r) {
+				if (r.message && r.message.length > 0) {
+					let valid_states = selected_states.filter(
+						(d) =>
+							!r.message.some(
+								(invalid) => invalid.name === d.state
+							)
+					);
+
+					if (valid_states.length !== selected_states.length) {
+						frm.set_value("custom_states", valid_states);
+					}
+				}
+			},
+		});
+	}
+}

--- a/changemakers/hooks.py
+++ b/changemakers/hooks.py
@@ -84,6 +84,7 @@ website_route_rules = [
 # include js in doctype views
 doctype_js = {
     "Stock Entry": "frappe_changemakers/overrides/stock_entry.js",
+    "Project": "frappe_changemakers/overrides/project.js",
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}


### PR DESCRIPTION
This pull request introduces custom filtering functionality for the `Project` form in the Frappe framework, enabling dynamic filtering of states based on selected countries. It also integrates the new functionality by updating the `hooks.py` file to include the corresponding JavaScript override.

### New functionality for `Project` form:

* Added a custom script in `changemakers/frappe_changemakers/overrides/project.js` to dynamically filter states (`custom_states`) based on the selected countries (`custom_project_countrys`). This includes:
  - A `refresh` event to initialize the state filter setup.
  - A `custom_project_countrys` event to trigger state filtering when countries are selected.
  - Helper functions `setup_state_filter` and `filter_states_by_selected_countries` to handle the filtering logic and ensure only valid states are displayed.

### Integration with the Frappe framework:

* Updated `changemakers/hooks.py` to include the new `project.js` override for the `Project` doctype, ensuring the custom filtering logic is applied when the `Project` form is used.