### PR TITLE
fix: Correct spelling of "Centre" in link filters for Recipient Type

### DIFF
--- a/changemakers/frappe_changemakers/doctype/donation_allocation_item/donation_allocation_item.json
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation_item/donation_allocation_item.json
@@ -76,7 +76,7 @@
    "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Recipient Type",
-   "link_filters": "[[\"DocType\",\"name\",\"in\", [\"Learning Center\", \"Student\", \"Beneficiary\"]]]",
+   "link_filters": "[[\"DocType\",\"name\",\"in\", [\"Learning Centre\", \"Student\", \"Beneficiary\"]]]",
    "options": "DocType"
   },
   {
@@ -94,7 +94,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-23 15:35:31.400263",
+ "modified": "2025-05-23 16:44:08.463165",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Donation Allocation Item",


### PR DESCRIPTION
This pull request includes one change to the `donation_allocation_item.json` file, primarily addressing a correction in the label text.

### Label correction:
* Updated the `link_filters` field to replace "Learning Center" with "Learning Centre" for consistency in terminology.
