### PR TITLE
feat: Rearrange field order in Donation Allocation Item

### DIFF
--- a/changemakers/frappe_changemakers/doctype/donation_allocation_item/donation_allocation_item.json
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation_item/donation_allocation_item.json
@@ -6,11 +6,12 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "amount",
-  "percentage",
   "column_break_adjg",
   "recipient_type",
   "recipient",
+  "column_break_rqny",
+  "amount",
+  "percentage",
   "accounting_dimensions_section",
   "project",
   "dimension_col_break",
@@ -88,13 +89,17 @@
    "in_standard_filter": 1,
    "label": "Recipient",
    "options": "recipient_type"
+  },
+  {
+   "fieldname": "column_break_rqny",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-23 16:44:08.463165",
+ "modified": "2025-05-27 12:29:26.009149",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Donation Allocation Item",


### PR DESCRIPTION
This pull request updates the `donation_allocation_item.json` file to adjust the field order. These changes aim to improve the structure and organization of the Donation Allocation Item Doctype.

Field order adjustments:

* Reordered fields in the `field_order` array, moving `amount` and `percentage` to follow a newly added `column_break_rqny` field. This change ensures better logical grouping of fields.
