### PR TITLE
fix(patch): remove legacy conflicting custom fields

### DIFF
--- a/changemakers/frappe_changemakers/patches/clear_custom_fields.py
+++ b/changemakers/frappe_changemakers/patches/clear_custom_fields.py
@@ -1,0 +1,13 @@
+import frappe
+
+def execute():
+    custom_fields = frappe.get_all(
+        "Custom Field", 
+        filters={"module": "Frappe Changemakers"},
+        pluck="name"
+    )
+    
+    for field in custom_fields:
+        frappe.delete_doc("Custom Field", field, ignore_permissions=True)
+        
+    frappe.db.commit()

--- a/changemakers/patches.txt
+++ b/changemakers/patches.txt
@@ -1,4 +1,5 @@
 [pre_model_sync]
+changemakers.frappe_changemakers.patches.clear_custom_fields
 
 [post_model_sync]
 changemakers.frappe_changemakers.patches.school_links # 6


### PR DESCRIPTION

<p>This pull request introduces a pre-model sync patch to clean up legacy custom fields associated with the <strong>Frappe Changemakers</strong> module. These fields may have been added during earlier development phases or from outdated configurations and could now lead to conflicts or redundancy during deployment. The patch ensures that these custom fields are systematically removed before model synchronization to maintain a clean and consistent schema.</p>
<hr>
<h2>Key Improvements</h2>
<h3>🧹 Patch Implementation: <code inline="">clear_custom_fields.py</code></h3>
<ul>
<li>
<p><strong>Location:</strong> <code inline="">changemakers/frappe_changemakers/patches/clear_custom_fields.py</code></p>
</li>
<li>
<p>The patch defines a function that:</p>
<ul>
<li>
<p>Uses <code inline="">frappe.get_all("Custom Field", {"module": "Frappe Changemakers"})</code> to retrieve all custom fields linked to the "Frappe Changemakers" module.</p>
</li>
<li>
<p>Iterates through the list of fields and calls <code inline="">frappe.delete_doc("Custom Field", field.name)</code> to delete each one.</p>
</li>
<li>
<p>Commits the changes using <code inline="">frappe.db.commit()</code> to ensure all deletions are applied immediately.</p>
</li>
</ul>
</li>
<li>
<p>The goal is to remove outdated or duplicate custom fields that are no longer required or are replaced by newer fixtures.</p>
</li>
</ul>
<hr>
<h3>🧩 Patch Registration in <code inline="">patches.txt</code></h3>
<ul>
<li>
<p><strong>Location:</strong> <code inline="">changemakers/patches.txt</code></p>
</li>
<li>
<p>The new patch (<code inline="">clear_custom_fields</code>) is registered under the <code inline="">[pre_model_sync]</code> section:</p>
<pre><code class="language-ini">[pre_model_sync]
changemakers.frappe_changemakers.patches.clear_custom_fields
</code></pre>

This ensures the patch runs before model synchronization (bench migrate) begins. By doing so, it avoids potential conflicts caused by custom fields that may clash with new field definitions or have been removed from the codebase but still exist in the database.

