### PR TITLE
feat: Add indentation for better hierarchy in DBA Report

### DIFF
--- a/changemakers/frappe_changemakers/report/donation_budget_allocation_report/donation_budget_allocation_report.py
+++ b/changemakers/frappe_changemakers/report/donation_budget_allocation_report/donation_budget_allocation_report.py
@@ -260,6 +260,7 @@ def get_data(filters=None):
                     "total_allocation_amount": "",
                     "donation_total_paid_amount": "",
                     "donation_unallocated_balance": "",
+                    "indent": 1,  # Indent account rows under budget
                     **account_monthly_amounts,
                 }
             )
@@ -288,6 +289,7 @@ def get_data(filters=None):
                         "total_donations": "",
                         "months_distributed": "",
                         "percentage": "",
+                        "indent": 2,  # Indent allocation items under accounts
                         **allocation_month_empty_data,
                     }
                 )
@@ -308,6 +310,7 @@ def get_data(filters=None):
                 "total_allocation_amount": "",
                 "donation_total_paid_amount": "",
                 "donation_unallocated_balance": "",
+                "indent": 0,  # Top-level budget rows
                 **month_data_amounts,
             }
         )


### PR DESCRIPTION
This pull request introduces indentation levels for account rows and allocation items in the get_data function to enhance the visual hierarchy of the report. It sets "indent" to 1 for account rows under budgets, 2 for allocation items under accounts, and 0 for top-level budget rows, improving readability and organization of the report data.

## Sample Preview

<img width="1337" height="909" alt="Collapsible Data" src="https://github.com/user-attachments/assets/38a00629-55ea-436f-afb2-2ea6c4106f0a" />
