### PR TITLE
feat(distribution): Add warehouse selection to distribution flow

### DIFF
--- a/changemakers/frappe_changemakers/overrides/project.js
+++ b/changemakers/frappe_changemakers/overrides/project.js
@@ -99,6 +99,18 @@ function open_distribution_modal(frm) {
 							}),
 						},
 						{
+							label: "Warehouse",
+							fieldname: "warehouse",
+							fieldtype: "Link",
+							options: "Warehouse",
+							reqd: 1,
+							get_query: () => ({
+								filters: {
+									disabled: 0,
+								},
+							}),
+						},
+						{
 							label: "Beneficiaries",
 							fieldname: "beneficiaries",
 							fieldtype: "Table",
@@ -108,17 +120,28 @@ function open_distribution_modal(frm) {
 							fields: [
 								{
 									fieldname: "beneficiary",
-									label: "Beneficiary",
+									label: "ID",
 									fieldtype: "Link",
 									options: "Beneficiary",
 									in_list_view: 1,
 									reqd: 1,
+									cols: 2,
 									get_query: () => ({
 										filters: {
 											branch: frm.doc.branch,
 											status: "Active",
 										},
 									}),
+								},
+								{
+									fieldname: "full_name",
+									label: "Full Name",
+									fieldtype: "Data",
+									in_list_view: 1,
+									reqd: 1,
+									read_only: 1,
+									cols: 4,
+									get_value: (d) => d.beneficiary_full_name,
 								},
 							],
 						},
@@ -131,6 +154,7 @@ function open_distribution_modal(frm) {
 								project: frm.doc.name,
 								bom: values.bom,
 								beneficiaries: values.beneficiaries,
+								warehouse: values.warehouse,
 							},
 							freeze: true,
 							callback: function (res) {

--- a/changemakers/frappe_changemakers/overrides/stock_entry_query.py
+++ b/changemakers/frappe_changemakers/overrides/stock_entry_query.py
@@ -56,7 +56,7 @@ def get_distribution_data(project):
 			"status": "Active",
 			"name": ["not in", list(used_beneficiaries_set)]
 		},
-		fields=["name as beneficiary"]
+		fields=["name as beneficiary", "beneficiary_no", "full_name"]
 	)
 
 	return {
@@ -66,7 +66,7 @@ def get_distribution_data(project):
  
 
 @frappe.whitelist()
-def create_food_stock_entries(project, bom, beneficiaries):
+def create_food_stock_entries(project, bom, beneficiaries, warehouse=None):
     """
     Creates a unique Stock Entry of type 'Distribution' for each beneficiary,
     populating it with items from the specified Bill of Materials (BOM).
@@ -94,17 +94,14 @@ def create_food_stock_entries(project, bom, beneficiaries):
     if not bom_items:
         frappe.throw(_("No BOM items found for the selected BOM."))
 
-    from_warehouse = None
-    if project_doc.custom_branch:
+    from_warehouse = warehouse
+    if project_doc.custom_branch and not from_warehouse:
         warehouse = frappe.get_value("Warehouse", {"name": ["like", f"%{project_doc.custom_branch}%"]}, "name")
         if warehouse:
             from_warehouse = warehouse
         else:
             frappe.msgprint(_(f"No warehouse found matching branch '{project_doc.custom_branch}'. "
                                "Stock Entry will be created without a source warehouse if not explicitly set."))
-    else:
-        frappe.msgprint(_("Project has no custom branch. Stock Entry will be created without a source warehouse."))
-
 
     created_stock_entries = [] 
 
@@ -123,7 +120,7 @@ def create_food_stock_entries(project, bom, beneficiaries):
             continue
 
         se = frappe.new_doc("Stock Entry")
-        se.stock_entry_type = "Distribution"
+        se.stock_entry_type = "Distribution" if frappe.db.exists("Stock Entry Type", "Distribution") else "Material Issue"
         se.project = project
         se.branch = project_doc.custom_branch
         se.cost_center = project_doc.cost_center

--- a/changemakers/hooks.py
+++ b/changemakers/hooks.py
@@ -7,7 +7,7 @@ app_description = "Empowering the people that do good."
 app_email = "hussain@frappe.io"
 app_license = "AGPL"
 
-required_apps = ["erpnext", "education", "non_profit"]
+required_apps = ["erpnext", "non_profit"]
 
 fixtures = [
     "Custom HTML Block",


### PR DESCRIPTION
Enhance the distribution modal with a required Warehouse field and display
beneficiary ID along with a read-only full name for clearer selection.

Key updates:
- Pass the selected warehouse to the backend for stock entry creation
- Use the selected warehouse as the source; if none, infer from the
  project's branch and notify the user if unavailable
- Fallback to an alternative stock entry type when 'Distribution' type
  is missing to improve compatibility