### PR TITLE
feat(allocation): Auto-calculate and enforce total allocation

### DIFF
--- a/changemakers/frappe_changemakers/doctype/donation_allocation/donation_allocation.js
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation/donation_allocation.js
@@ -13,6 +13,10 @@ frappe.ui.form.on("Donation Allocation", {
 		}
 	},
 
+	before_save: function (frm) {
+		update_total_amount(frm);
+	},
+
 	donation_total_paid_amount(frm) {
 		calculate_unallocated_amount(frm);
 	},
@@ -47,6 +51,10 @@ frappe.ui.form.on("Donation Allocation Item", {
 		refresh_field("account", cdn, "items");
 	},
 
+	amount: function (frm, cdt, cdn) {
+		update_total_amount(frm);
+	},
+
 	items_add: function (frm, cdt, cdn) {
 		if (frm.doc.payment_entry) {
 			frappe.model.set_value(
@@ -56,6 +64,12 @@ frappe.ui.form.on("Donation Allocation Item", {
 				frm.doc.payment_entry
 			);
 		}
+
+		update_total_amount(frm);
+	},
+
+	items_remove: function (frm, cdt, cdn) {
+		update_total_amount(frm);
 	},
 });
 
@@ -226,4 +240,12 @@ function calculate_unallocated_amount(frm) {
 			}
 		},
 	});
+}
+
+function update_total_amount(frm) {
+	let total = 0;
+	(frm.doc.items || []).forEach((row) => {
+		total += flt(row.amount || 0);
+	});
+	frm.set_value("total_amount", total);
 }

--- a/changemakers/frappe_changemakers/doctype/donation_allocation/donation_allocation.json
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation/donation_allocation.json
@@ -92,6 +92,8 @@
    "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Total Allocation Amount",
+   "non_negative": 1,
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -166,7 +168,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-01 11:41:26.293412",
+ "modified": "2025-12-19 12:48:44.118466",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Donation Allocation",


### PR DESCRIPTION
Automatically calculate and store the total allocation whenever item
amounts change, items are added or removed, or before saving.

Key improvements:
- Keep total allocation synchronized with line items
- Mark total field as read-only and non-negative to prevent manual edits
- Ensure accurate unallocated amount computations
- Prevent mismatches between line-item sums and recorded total