### PR TITLE
feat(beneficiary): Add beneficiary types and supplier lifecycle support

### DIFF
--- a/changemakers/fixtures/beneficiary_type.json
+++ b/changemakers/fixtures/beneficiary_type.json
@@ -1,0 +1,20 @@
+[
+ {
+  "docstatus": 0,
+  "doctype": "Beneficiary Type",
+  "modified": "2026-01-16 13:59:32.737107",
+  "name": "Student"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Beneficiary Type",
+  "modified": "2026-01-16 13:59:41.838096",
+  "name": "Others"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Beneficiary Type",
+  "modified": "2026-01-16 14:00:44.932173",
+  "name": "Teacher"
+ }
+]

--- a/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.js
+++ b/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.js
@@ -92,7 +92,62 @@ frappe.ui.form.on("Beneficiary", {
 			}
 		}
 
+		if (frm.doc.supplier) {
+			frappe.db
+				.count("Bank Account", {
+					filters: {
+						party_type: "Supplier",
+						party: frm.doc.supplier,
+					},
+				})
+				.then((count) => {
+					if (count > 0) {
+						frm.set_df_property("create_bank_account", "hidden", 1);
+					}
+				});
+		}
+
 		calculate_and_set_age(frm);
+	},
+
+	create_supplier: (frm) => {
+		frm.call({
+			method: "create_supplier",
+			doc: frm.doc,
+			callback: function (r) {
+				if (r.message) {
+					frappe.msgprint("Supplier " + r.message + " created.");
+				}
+			},
+		});
+	},
+
+	create_bank_account: (frm) => {
+		if (frm.doc.supplier) {
+			frappe.db
+				.count("Bank Account", {
+					filters: {
+						party_type: "Supplier",
+						party: frm.doc.supplier,
+					},
+				})
+				.then((count) => {
+					if (count === 0) {
+						frappe.new_doc("Bank Account", {
+							party_type: "Supplier",
+							party: frm.doc.supplier,
+						});
+					} else {
+						frappe.msgprint(
+							__("Bank Account already exists for this Supplier.")
+						);
+					}
+				});
+		} else {
+			frappe.msgprint(
+				__("Please create Supplier before creating Bank Account.")
+			);
+		}
 	},
 
 	recruitment_phase: (frm) => {

--- a/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.json
+++ b/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.json
@@ -12,42 +12,43 @@
   "first_name",
   "last_name",
   "full_name",
-  "recruitment_phase",
-  "branch",
-  "student",
   "column_break_3",
   "beneficiary_no",
+  "beneficiary_type",
+  "column_break_4",
   "gender",
   "dob",
   "age",
-  "donor",
-  "beneficiary_type",
-  "column_break_4",
-  "collector",
-  "phone_number",
-  "email",
-  "religion",
-  "social_category",
-  "languages_known",
+  "recruitment_section",
+  "recruitment_phase",
+  "column_break_qgbq",
+  "branch",
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
+  "donor",
   "section_break_vzck",
   "created_by",
   "section_break_uwdz",
   "bottom_save_button",
   "address_contact_tab",
-  "address_html",
   "column_break_ifez",
   "contact_html",
+  "column_break_sytn",
+  "address_html",
+  "section_break_epas",
+  "email",
+  "phone_number",
+  "column_break_flhe",
+  "native_full_address",
   "location_section",
   "state",
   "district",
+  "column_break_kcuc",
   "zone",
   "ward",
+  "column_break_xrsq",
   "habitation",
-  "section_break_myup",
-  "native_full_address",
   "point_of_contact_section",
   "poc_name",
   "column_break_23",
@@ -73,19 +74,27 @@
   "course_level",
   "identity_tab",
   "identity_section",
-  "ethnicity",
-  "nationality",
+  "languages_known",
+  "religion",
+  "column_break_stbz",
   "residency",
+  "nationality",
   "column_break_17",
   "place_of_birth",
-  "is_identity_proof_available",
+  "ethnicity",
+  "social_category",
   "section_break_glmz",
+  "is_identity_proof_available",
   "identity_proofs",
   "tab_4_tab",
   "health_section",
   "disability_condition",
   "column_break_24",
   "chronic_illness",
+  "native_place_section",
+  "native_state",
+  "column_break_iefk",
+  "native_district",
   "history_section",
   "has_history",
   "previous_beneficiary_details",
@@ -106,16 +115,21 @@
   "section_break_bsgr",
   "housing_description",
   "tab_6_tab",
+  "supplier",
+  "create_supplier",
+  "create_bank_account",
+  "column_break_zvdz",
+  "student",
+  "column_break_uvuj",
+  "collector",
+  "section_break_zarq",
   "status",
   "replaced_by",
+  "column_break_tvlz",
   "activation_date",
   "archive_date",
-  "column_break_tvlz",
+  "column_break_zfbd",
   "archive_reason",
-  "native_place_section",
-  "native_state",
-  "column_break_iefk",
-  "native_district",
   "education_section",
   "education_level",
   "is_employeed",
@@ -259,15 +273,13 @@
    "in_standard_filter": 1,
    "label": "Age",
    "non_negative": 1,
-   "reqd": 1,
    "search_index": 1
   },
   {
    "fieldname": "gender",
    "fieldtype": "Link",
    "label": "Gender",
-   "options": "Gender",
-   "reqd": 1
+   "options": "Gender"
   },
   {
    "default": "Unknown",
@@ -384,10 +396,6 @@
    "fieldtype": "Link",
    "label": "District",
    "options": "District"
-  },
-  {
-   "fieldname": "section_break_myup",
-   "fieldtype": "Section Break"
   },
   {
    "description": "Include block, GP, village or any other identifier info",
@@ -546,6 +554,7 @@
    "no_copy": 1
   },
   {
+   "depends_on": "eval: doc.archive_date",
    "fieldname": "archive_reason",
    "fieldtype": "Small Text",
    "label": "Archive reason"
@@ -631,8 +640,7 @@
   {
    "fieldname": "dob",
    "fieldtype": "Date",
-   "label": "Date of Birth",
-   "reqd": 1
+   "label": "Date of Birth"
   },
   {
    "allow_in_quick_entry": 1,
@@ -675,9 +683,9 @@
   },
   {
    "fieldname": "beneficiary_type",
-   "fieldtype": "Select",
+   "fieldtype": "Link",
    "label": "Beneficiary Type",
-   "options": "\nStudent\nTeacher\nOthers"
+   "options": "Beneficiary Type"
   },
   {
    "fieldname": "residency",
@@ -784,6 +792,73 @@
    "fieldname": "household_size",
    "fieldtype": "Int",
    "label": "Household Size"
+  },
+  {
+   "fieldname": "supplier",
+   "fieldtype": "Link",
+   "label": "Supplier",
+   "options": "Supplier"
+  },
+  {
+   "fieldname": "column_break_sytn",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_zvdz",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_uvuj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_stbz",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "recruitment_section",
+   "fieldtype": "Section Break",
+   "label": "Recruitment"
+  },
+  {
+   "fieldname": "column_break_qgbq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_zarq",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_epas",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_flhe",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_kcuc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_xrsq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: !doc.supplier",
+   "fieldname": "create_supplier",
+   "fieldtype": "Button",
+   "label": "Create Supplier"
+  },
+  {
+   "fieldname": "column_break_zfbd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.supplier",
+   "fieldname": "create_bank_account",
+   "fieldtype": "Button",
+   "label": "Create Bank Account"
   }
  ],
  "image_field": "image",
@@ -815,7 +890,7 @@
    "link_fieldname": "beneficiary"
   }
  ],
- "modified": "2026-01-15 12:36:20.965189",
+ "modified": "2026-01-16 14:42:17.013231",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Beneficiary",

--- a/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.py
+++ b/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.py
@@ -41,6 +41,8 @@ class Beneficiary(Document):
             if user and user != frappe.session.user:  
                 frappe.delete_doc("User", user, ignore_permissions=True)
 
+        if settings.generate_supplier_when_beneficiary_is_created:
+            self.create_supplier()
         
     def before_save(self):
         self.set_created_by()
@@ -75,7 +77,7 @@ class Beneficiary(Document):
             )
 
     def validate_age(self):
-        if not (self.age < 120):
+        if self.age and not (self.age < 120):
             frappe.throw(f"Value of {frappe.bold('Age')} should be less than 120!")
 
     def validate_phone_number_fields(self):
@@ -96,6 +98,28 @@ class Beneficiary(Document):
 
     def onload(self):
         load_address_and_contact(self)
+
+    @frappe.whitelist()
+    def create_supplier(self):
+        if self.supplier:
+            return
+        
+        if not frappe.db.exists("Supplier Group", "Beneficiary"):
+            supplier_group = frappe.new_doc("Supplier Group")
+            supplier_group.supplier_group_name = "Beneficiary"
+            supplier_group.flags.ignore_permissions = True
+            supplier_group.insert()
+
+        supplier = frappe.new_doc("Supplier")
+        supplier.supplier_name = self.full_name
+        supplier.supplier_type = "Individual"
+        supplier.supplier_group = "Beneficiary"
+
+        supplier.flags.ignore_permissions = True
+        supplier.insert()
+        self.supplier = supplier.name
+        self.save()
+        return supplier.name
 
 
 def generate_beneficiary_no(doc):

--- a/changemakers/frappe_changemakers/doctype/beneficiary_type/beneficiary_type.js
+++ b/changemakers/frappe_changemakers/doctype/beneficiary_type/beneficiary_type.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, hussain@frappe.io and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Beneficiary Type", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/changemakers/frappe_changemakers/doctype/beneficiary_type/beneficiary_type.json
+++ b/changemakers/frappe_changemakers/doctype/beneficiary_type/beneficiary_type.json
@@ -1,0 +1,45 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "prompt",
+ "creation": "2026-01-16 13:58:33.163763",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_gkd4"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_gkd4",
+   "fieldtype": "Section Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-01-16 13:58:43.306132",
+ "modified_by": "Administrator",
+ "module": "Frappe Changemakers",
+ "name": "Beneficiary Type",
+ "naming_rule": "Set by user",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/changemakers/frappe_changemakers/doctype/beneficiary_type/beneficiary_type.py
+++ b/changemakers/frappe_changemakers/doctype/beneficiary_type/beneficiary_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, hussain@frappe.io and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class BeneficiaryType(Document):
+	pass

--- a/changemakers/frappe_changemakers/doctype/beneficiary_type/test_beneficiary_type.py
+++ b/changemakers/frappe_changemakers/doctype/beneficiary_type/test_beneficiary_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, hussain@frappe.io and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBeneficiaryType(FrappeTestCase):
+	pass

--- a/changemakers/frappe_changemakers/doctype/changemakers_settings/changemakers_settings.json
+++ b/changemakers/frappe_changemakers/doctype/changemakers_settings/changemakers_settings.json
@@ -11,6 +11,7 @@
   "enable_food_distribution",
   "column_break_kltk",
   "generate_supplier_when_learning_center_is_created",
+  "generate_supplier_when_beneficiary_is_created",
   "beneficiary_section",
   "manage_beneficiary_lifecycle",
   "allow_beneficiary_status_editing",
@@ -55,7 +56,7 @@
    "default": "0",
    "fieldname": "generate_supplier_when_learning_center_is_created",
    "fieldtype": "Check",
-   "label": "Generate Supplier When Learning Center Is Created"
+   "label": "Generate Supplier When Learning Center is Created"
   },
   {
    "fieldname": "column_break_kltk",
@@ -81,12 +82,18 @@
    "fieldtype": "Link",
    "label": "Default Beneficiary Status",
    "options": "Beneficiary Status"
+  },
+  {
+   "default": "0",
+   "fieldname": "generate_supplier_when_beneficiary_is_created",
+   "fieldtype": "Check",
+   "label": "Generate Supplier When Beneficiary is Created"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-17 12:50:35.503747",
+ "modified": "2026-01-16 14:05:51.849982",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Changemakers Settings",

--- a/changemakers/frappe_changemakers/doctype/donation_allocation_policy/donation_allocation_policy.json
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation_policy/donation_allocation_policy.json
@@ -12,7 +12,9 @@
   "effective_from",
   "effective_to",
   "section_break_qlvo",
-  "notes"
+  "notes",
+  "section_break_abbx",
+  "criteria"
  ],
  "fields": [
   {
@@ -50,12 +52,22 @@
    "fieldname": "notes",
    "fieldtype": "Text Editor",
    "label": "Notes"
+  },
+  {
+   "fieldname": "section_break_abbx",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "criteria",
+   "fieldtype": "Table",
+   "label": "Criteria",
+   "options": "Donation Allocation Criteria"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-15 11:53:53.813792",
+ "modified": "2026-01-15 14:59:08.511167",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Donation Allocation Policy",


### PR DESCRIPTION
Introduce structured beneficiary categorization and enable supplier management for beneficiaries.

Key changes:
- Add a Beneficiary Type doctype with fixtures and tests to model
  beneficiary categories
- Convert beneficiary_type to a Link field and reorganize form layout
  and fields for improved UX
- Enable supplier lifecycle for beneficiaries:
  - Add server-side supplier creation with an opt-in setting
  - Add client actions to create suppliers and bank accounts
  - Prevent creation of duplicate bank accounts via UI checks
- Prevent age validation from throwing errors when age is empty
- Add a criteria table to the donation allocation policy to support structured allocation rules