### PR TITLE
feat(allocation): Add cash/item allocation and beneficiaries table

### DIFF
--- a/changemakers/frappe_changemakers/doctype/donation_allocation_beneficiary/donation_allocation_beneficiary.js
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation_beneficiary/donation_allocation_beneficiary.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, hussain@frappe.io and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Donation Allocation Beneficiary", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/changemakers/frappe_changemakers/doctype/donation_allocation_beneficiary/donation_allocation_beneficiary.json
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation_beneficiary/donation_allocation_beneficiary.json
@@ -1,0 +1,106 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-01-16 15:10:54.148414",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "beneficiary",
+  "beneficiary_name",
+  "beneficiary_no",
+  "column_break_pbpz",
+  "collector",
+  "household_size",
+  "amount"
+ ],
+ "fields": [
+  {
+   "fieldname": "beneficiary",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Beneficiary",
+   "options": "Beneficiary",
+   "reqd": 1
+  },
+  {
+   "columns": 2,
+   "fetch_from": "beneficiary.beneficiary_no",
+   "fieldname": "beneficiary_no",
+   "fieldtype": "Data",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Beneficiary No",
+   "read_only": 1
+  },
+  {
+   "columns": 1,
+   "fieldname": "household_size",
+   "fieldtype": "Int",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Household Size",
+   "non_negative": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Amount",
+   "non_negative": 1
+  },
+  {
+   "columns": 1,
+   "fieldname": "collector",
+   "fieldtype": "Data",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Collector",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_pbpz",
+   "fieldtype": "Column Break"
+  },
+  {
+   "columns": 2,
+   "fetch_from": "beneficiary.full_name",
+   "fieldname": "beneficiary_name",
+   "fieldtype": "Data",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Beneficiary Name",
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-01-16 15:41:16.470324",
+ "modified_by": "Administrator",
+ "module": "Frappe Changemakers",
+ "name": "Donation Allocation Beneficiary",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/changemakers/frappe_changemakers/doctype/donation_allocation_beneficiary/donation_allocation_beneficiary.py
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation_beneficiary/donation_allocation_beneficiary.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, hussain@frappe.io and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class DonationAllocationBeneficiary(Document):
+	pass

--- a/changemakers/frappe_changemakers/doctype/donation_allocation_beneficiary/test_donation_allocation_beneficiary.py
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation_beneficiary/test_donation_allocation_beneficiary.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, hussain@frappe.io and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestDonationAllocationBeneficiary(FrappeTestCase):
+	pass

--- a/changemakers/frappe_changemakers/doctype/donation_allocation_panel/donation_allocation_panel.js
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation_panel/donation_allocation_panel.js
@@ -5,7 +5,6 @@ frappe.ui.form.on("Donation Allocation Panel", {
 	setup: function (frm) {
 		frm.trigger("set_query");
 		frm.trigger("set_allocation_defaults");
-
 		frm.events.setup_beneficiary_filter_group(frm);
 	},
 
@@ -16,29 +15,32 @@ frappe.ui.form.on("Donation Allocation Panel", {
 		frm.trigger("set_primary_action");
 	},
 
-	collector: function (frm) {
-		frm.trigger("get_beneficiaries");
-	},
-	gender: function (frm) {
-		frm.trigger("get_beneficiaries");
-	},
-	name: function (frm) {
-		frm.trigger("get_beneficiaries");
-	},
-	household_size: function (frm) {
-		frm.trigger("get_beneficiaries");
-	},
-	from_date: function (frm) {
-		frm.trigger("get_beneficiaries");
-	},
-	to_date: function (frm) {
-		frm.trigger("get_beneficiaries");
+	collector: (frm) => frm.trigger("get_beneficiaries"),
+	gender: (frm) => frm.trigger("get_beneficiaries"),
+	name: (frm) => frm.trigger("get_beneficiaries"),
+	household_size: (frm) => frm.trigger("get_beneficiaries"),
+	from_date: (frm) => frm.trigger("get_beneficiaries"),
+	to_date: (frm) => frm.trigger("get_beneficiaries"),
+
+	amount: function (frm) {
+		if (frm.doc.allocation_type === "Cash" && frm.doc.amount > 0) {
+			frm.doc.beneficiaries.forEach((row) => {
+				if (!row.amount || row.amount == 0) {
+					frappe.model.set_value(
+						row.doctype,
+						row.name,
+						"amount",
+						frm.doc.amount
+					);
+				}
+			});
+			frm.refresh_field("beneficiaries");
+		}
 	},
 
 	set_allocation_defaults(frm) {
 		frm.set_value({
 			from_date: frappe.datetime.get_today(),
-			to_date: null,
 			company: frappe.defaults.get_default("company"),
 		});
 	},
@@ -74,88 +76,28 @@ frappe.ui.form.on("Donation Allocation Panel", {
 				advanced_filters: JSON.stringify(frm.advanced_filters || {}),
 			},
 		}).then((r) => {
-			frm.beneficiaries_datatable =
-				frm.events.render_beneficiaries_datatable(frm, r.message);
+			frm.clear_table("beneficiaries");
+			if (r.message) {
+				r.message.forEach((d) => {
+					let row = frm.add_child("beneficiaries");
+					row.beneficiary = d.name;
+					row.beneficiary_no = d.beneficiary_no;
+					row.beneficiary_name = d.full_name;
+					row.collector = d.collector;
+					row.household_size = d.household_size;
+					if (frm.doc.allocation_type === "Cash") {
+						row.amount = frm.doc.amount || 0;
+					}
+				});
+			}
+			frm.refresh_field("beneficiaries");
 		});
-	},
-
-	render_beneficiaries_datatable(frm, beneficiaries) {
-		const columns = frm.events.get_beneficiaries_datatable_columns();
-
-		const wrapper = frm.get_field("beneficiaries_html").$wrapper;
-		wrapper.empty();
-
-		if (!beneficiaries || beneficiaries.length === 0) {
-			wrapper.html(`
-				<div class="text-muted text-center" style="padding: 40px;">
-					<i class="fa fa-users fa-3x" style="opacity: 0.3; margin-bottom: 15px;"></i>
-					<p>${__("No beneficiaries found matching the criteria")}</p>
-					<small>${__("Adjust your filters to find eligible beneficiaries")}</small>
-				</div>
-			`);
-			return;
-		}
-
-		return new frappe.DataTable(wrapper[0], {
-			columns: columns,
-			data: beneficiaries,
-			checkboxColumn: true,
-			layout: "fluid",
-			cellHeight: 40,
-			noDataMessage: __("No beneficiaries found matching the criteria"),
-		});
-	},
-
-	get_beneficiaries_datatable_columns() {
-		return [
-			{
-				name: "name",
-				id: "name",
-				content: __("Beneficiary ID"),
-				width: 120,
-				format: (value, row, column, data) => {
-					return value
-						? `<a href="/app/beneficiary/${data.name}" target="_blank">${value}</a>`
-						: "";
-				},
-			},
-			{
-				name: "full_name",
-				id: "full_name",
-				content: __("Name"),
-				width: 180,
-				format: (value, row, column, data) => {
-					return value
-						? `<a href="/app/beneficiary/${data.name}" target="_blank">${value}</a>`
-						: "";
-				},
-			},
-			{
-				name: "collector",
-				id: "collector",
-				content: __("Collector"),
-				width: 150,
-			},
-			{ name: "gender", id: "gender", content: __("Gender"), width: 100 },
-			{
-				name: "household_size",
-				id: "household_size",
-				content: __("Household Size"),
-				width: 120,
-			},
-		].map((x) => ({
-			...x,
-			editable: false,
-			focusable: false,
-			dropdown: false,
-			align: "left",
-		}));
 	},
 
 	set_query(frm) {
-		frm.set_query("branch", function () {
-			return { filters: { company: frm.doc.company } };
-		});
+		frm.set_query("branch", () => ({
+			filters: { company: frm.doc.company },
+		}));
 	},
 
 	set_primary_action(frm) {
@@ -165,7 +107,7 @@ frappe.ui.form.on("Donation Allocation Panel", {
 	},
 
 	allocate_beneficiaries(frm) {
-		if (!frm.beneficiaries_datatable) {
+		if (!frm.doc.beneficiaries || frm.doc.beneficiaries.length === 0) {
 			frappe.msgprint(__("No beneficiaries loaded"));
 			return;
 		}
@@ -177,46 +119,35 @@ frappe.ui.form.on("Donation Allocation Panel", {
 
 		const missing_fields = required_fields.filter((f) => !frm.doc[f]);
 		if (missing_fields.length) {
-			frappe.msgprint({
-				title: __("Missing Required Fields"),
-				message: __(
-					"Please ensure the following required fields are filled: {0}",
-					[missing_fields.join(", ")]
-				),
-				indicator: "error",
-			});
+			frappe.msgprint(
+				__("Missing fields: {0}", [missing_fields.join(", ")])
+			);
 			return;
 		}
 
-		if (!frm.doc.items || frm.doc.items.length === 0) {
-			frappe.msgprint({
-				title: __("No Items Found"),
-				message: __(
-					"Please add at least one item to allocate donations."
-				),
-				indicator: "error",
-			});
+		if (
+			frm.doc.allocation_type == "Items" &&
+			(!frm.doc.items || frm.doc.items.length === 0)
+		) {
+			frappe.msgprint(__("Please add at least one item."));
 			return;
 		}
 
-		const check_map = frm.beneficiaries_datatable.rowmanager.checkMap;
-		const selected_beneficiaries = [];
-
-		check_map.forEach((is_checked, idx) => {
-			if (is_checked) {
-				selected_beneficiaries.push(
-					frm.beneficiaries_datatable.datamanager.data[idx].name
-				);
-			}
-		});
+		const selected_beneficiaries = frm.doc.beneficiaries
+			.filter((row) => row.__checked)
+			.map((row) => row.beneficiary);
 
 		if (!selected_beneficiaries.length) {
-			frappe.msgprint(__("No beneficiaries selected"));
+			frappe.msgprint(
+				__(
+					"Please select beneficiaries from the table using the checkboxes."
+				)
+			);
 			return;
 		}
 
 		frappe.confirm(
-			__("Allocate donations to {0} beneficiary(ies)?", [
+			__("Allocate donations to {0} selected beneficiary(ies)?", [
 				selected_beneficiaries.length,
 			]),
 			() =>
@@ -235,36 +166,45 @@ frappe.ui.form.on("Donation Allocation Panel", {
 			freeze: true,
 			freeze_message: __("Allocating Donations"),
 		}).then((r) => {
-			if (r.message.failed && !r.message.success) return;
-			frappe.msgprint(__("Donation allocation completed"));
-			frm.trigger("get_beneficiaries");
+			if (r.message && !r.message.failed) {
+				frappe.msgprint(__("Donation allocation completed"));
+				frm.trigger("get_beneficiaries");
+			}
 		});
 	},
 });
 
 frappe.ui.form.on("Donation Allocation Item", {
-	rate: function (frm, cdt, cdn) {
-		update_total_amount(frm);
-	},
+	rate: (frm) => update_items_total_amount(frm),
+	qty: (frm) => update_items_total_amount(frm),
+	items_add: (frm) => update_items_total_amount(frm),
+	items_remove: (frm) => update_items_total_amount(frm),
+});
 
-	amount: function (frm, cdt, cdn) {
+frappe.ui.form.on("Donation Allocation Beneficiary", {
+	amount: (frm) => update_total_amount(frm),
+	beneficiaries_add: function (frm, cdt, cdn) {
+		if (frm.doc.allocation_type === "Cash") {
+			frappe.model.set_value(cdt, cdn, "amount", frm.doc.amount || 0);
+		}
 		update_total_amount(frm);
 	},
-
-	items_add: function (frm, cdt, cdn) {
-		update_total_amount(frm);
-	},
-
-	items_remove: function (frm, cdt, cdn) {
-		update_total_amount(frm);
-	},
+	beneficiaries_remove: (frm) => update_total_amount(frm),
 });
 
 function update_total_amount(frm) {
+	let total = 0;
+	(frm.doc.beneficiaries || []).forEach((row) => {
+		total += flt(row.amount || 0);
+	});
+	frm.set_value("total_amount", total);
+}
+
+function update_items_total_amount(frm) {
 	let total = 0;
 	(frm.doc.items || []).forEach((row) => {
 		row.amount = flt(row.rate || 0) * flt(row.qty || 0);
 		total += flt(row.amount || 0);
 	});
-	frm.set_value("total_amount", total);
+	frm.set_value("total_items_amount", total);
 }

--- a/changemakers/frappe_changemakers/doctype/donation_allocation_panel/donation_allocation_panel.json
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation_panel/donation_allocation_panel.json
@@ -7,18 +7,23 @@
  "field_order": [
   "allocation_section",
   "column_break_16",
+  "allocation_type",
   "donation",
   "donor",
-  "project",
-  "cost_center",
   "column_break_vkxq",
-  "company",
   "from_date",
   "to_date",
+  "amount",
+  "column_break_pvqe",
+  "company",
   "donation_allocation_policy",
+  "accounting_dimensions_section",
+  "cost_center",
+  "column_break_qxej",
+  "project",
   "allocation_items_section",
   "items",
-  "total_amount",
+  "total_items_amount",
   "quick_filters_section",
   "collector",
   "gender",
@@ -28,7 +33,9 @@
   "advanced_filters_section",
   "filter_list",
   "select_beneficiaries_section",
-  "beneficiaries_html"
+  "beneficiaries_html",
+  "beneficiaries",
+  "total_amount"
  ],
  "fields": [
   {
@@ -52,6 +59,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "collapsible": 1,
    "fieldname": "quick_filters_section",
    "fieldtype": "Section Break",
    "label": "Quick Filters"
@@ -156,6 +164,7 @@
    "options": "Cost Center"
   },
   {
+   "depends_on": "eval: doc.allocation_type == \"Items\"",
    "fieldname": "allocation_items_section",
    "fieldtype": "Section Break",
    "label": "Allocation Items"
@@ -164,21 +173,58 @@
    "fieldname": "items",
    "fieldtype": "Table",
    "label": "Items",
-   "options": "Donation Allocation Item",
+   "mandatory_depends_on": "eval: doc.allocation_type == \"Items\"",
+   "options": "Donation Allocation Item"
+  },
+  {
+   "fieldname": "column_break_pvqe",
+   "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Dimensions"
+  },
+  {
+   "fieldname": "column_break_qxej",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "allocation_type",
+   "fieldtype": "Select",
+   "label": "Allocation Type",
+   "options": "\nCash\nItems",
    "reqd": 1
+  },
+  {
+   "depends_on": "eval: doc.allocation_type == \"Cash\"",
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "label": "Amount"
+  },
+  {
+   "fieldname": "beneficiaries",
+   "fieldtype": "Table",
+   "label": "Beneficiaries",
+   "options": "Donation Allocation Beneficiary"
   },
   {
    "fieldname": "total_amount",
    "fieldtype": "Currency",
-   "label": "Total Amount",
-   "read_only": 1
+   "label": "Total Amount"
+  },
+  {
+   "fieldname": "total_items_amount",
+   "fieldtype": "Currency",
+   "label": "Total Items Amount"
   }
  ],
  "hide_toolbar": 1,
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2026-01-15 13:40:34.004095",
+ "modified": "2026-01-16 15:28:48.413119",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Donation Allocation Panel",

--- a/changemakers/frappe_changemakers/doctype/donation_allocation_panel/donation_allocation_panel.py
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation_panel/donation_allocation_panel.py
@@ -18,9 +18,13 @@ class DonationAllocationPanel(Document):
             advanced_filters = json.loads(advanced_filters)
 
         query_filters = {}
-        for key in ["collector", "gender", "beneficiary_no", "household_size"]:
+        for key in ["collector", "gender", "beneficiary_no"]:
             if getattr(self, key, None) not in (None, ""):
                 query_filters[key] = getattr(self, key)
+        
+        household_size = getattr(self, "household_size", None)
+        if household_size and household_size > 0:
+            query_filters["household_size"] = household_size
 
         if advanced_filters:
             for key, value in advanced_filters.items():


### PR DESCRIPTION
Introduce explicit allocation types (Cash vs Items) and replace the client-side datatable with a dedicated beneficiaries child table.

Key changes:
- Add allocation types to distinguish Cash and Items flows
- Introduce a beneficiaries child table for structured selection
- Auto-populate beneficiary amounts for cash allocations
- Compute separate totals for item allocations and beneficiary cash
- Update event handlers and validations to use table rows and checkbox
  selection
- Improve user feedback and freeze handling during allocation actions
- Fix backend household_size filtering to apply only when a positive value is provided