### PR TITLE
feat(donation-disbursement): add SO validation and refined entry creation

### DIFF
--- a/changemakers/frappe_changemakers/doctype/beneficiary_disbursement_entry_party/beneficiary_disbursement_entry_party.json
+++ b/changemakers/frappe_changemakers/doctype/beneficiary_disbursement_entry_party/beneficiary_disbursement_entry_party.json
@@ -92,12 +92,14 @@
    "read_only": 1
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "payment_entry",
    "fieldtype": "Link",
    "label": "Payment Entry",
    "options": "Payment Entry"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "stock_entry",
    "fieldtype": "Link",
    "label": "Stock Entry",
@@ -118,7 +120,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-28 10:29:06.700896",
+ "modified": "2026-02-02 07:39:59.542904",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Beneficiary Disbursement Entry Party",

--- a/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.js
+++ b/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.js
@@ -5,12 +5,12 @@ var in_progress = false;
 frappe.ui.form.on("Donation Disbursement Entry", {
 	setup: function (frm) {
 		frm.events.setup_beneficiary_filter_group(frm);
-		if (frm.doc.docstatus == 0 && !frm.is_new()) {
-			frm.trigger("render_custom_buttons");
-		}
 	},
 
 	onload: function (frm) {
+		if (frm.doc.docstatus == 0 && !frm.is_new()) {
+			frm.trigger("render_custom_buttons");
+		}
 		if (!frm.doc.from_date) {
 			frm.set_value("from_date", frappe.datetime.nowdate());
 		}
@@ -52,15 +52,17 @@ frappe.ui.form.on("Donation Disbursement Entry", {
 		if (frm.is_dirty()) {
 			frm.page.set_primary_action(__("Save"), () => frm.save());
 		} else {
-			if (frm.doc.docstatus === 0 && !frm.is_new()) {
-				if (!(frm.doc.beneficiaries || []).length) {
+			if (frm.doc.docstatus === 0) {
+				if (!(frm.doc.beneficiaries || []).length && !frm.is_new()) {
 					frm.page.set_primary_action(
 						__("Get Beneficiaries"),
 						function () {
 							frm.events.get_beneficiary_details(frm);
 						},
 					);
-				} else if (!frm.doc.entries_created) {
+				}
+			} else if (frm.doc.docstatus === 1) {
+				if (!frm.doc.entries_created) {
 					let label =
 						frm.doc.allocation_type === "Cash"
 							? __("Create Payment Entries")
@@ -68,32 +70,30 @@ frappe.ui.form.on("Donation Disbursement Entry", {
 					frm.page.set_primary_action(label, () => {
 						frm.events.process_disbursement(frm);
 					});
+				} else {
+					frappe.call({
+						method: "frappe.client.get_list",
+						args: {
+							doctype: "Sales Invoice",
+							fields: ["name"],
+							filters: {
+								donation_disbursement_entry: frm.doc.name,
+							},
+						},
+						callback: function (r) {
+							if (r.message && r.message.length > 0) {
+							} else {
+								frm.add_custom_button(
+									__("Create Sales Invoice"),
+									function () {
+										frm.events.create_sales_invoice(frm);
+									},
+								).addClass("btn-primary");
+							}
+						},
+					});
 				}
 			}
-		}
-
-		if (frm.doc.docstatus === 1) {
-			frappe.call({
-				method: "frappe.client.get_list",
-				args: {
-					doctype: "Sales Invoice",
-					fields: ["name"],
-					filters: {
-						donation_disbursement_entry: frm.doc.name,
-					},
-				},
-				callback: function (r) {
-					if (r.message && r.message.length > 0) {
-					} else {
-						frm.add_custom_button(
-							__("Create Sales Invoice"),
-							function () {
-								frm.events.create_sales_invoice(frm);
-							},
-						).addClass("btn-primary");
-					}
-				},
-			});
 		}
 	},
 
@@ -163,35 +163,23 @@ frappe.ui.form.on("Donation Disbursement Entry", {
 	create_sales_invoice: function (frm) {
 		frappe.call({
 			doc: frm.doc,
-			method: "get_invoice_details",
+			method: "create_sales_invoice",
 			freeze: true,
 			callback: function (r) {
 				if (!r.message) return;
 
 				const data = r.message;
 
-				frappe.model.with_doctype("Sales Invoice", function () {
-					let new_invoice = frappe.model.get_new_doc("Sales Invoice");
-
-					new_invoice.currency = data.currency;
-					new_invoice.customer = data.customer;
-					new_invoice.donation_disbursement_entry = frm.doc.name;
-					Object.values(data.items).forEach((item) => {
-						let child_row = frappe.model.add_child(
-							new_invoice,
-							"items",
-						);
-
-						child_row.item_code = item.item_code;
-						child_row.item_name = item.item_name;
-						child_row.qty = item.qty;
-						child_row.rate = item.rate;
-						child_row.amount = item.amount;
-						child_row.uom = item.uom;
-					});
-
-					frappe.set_route("Form", "Sales Invoice", new_invoice.name);
-				});
+				if (!data.sales_invoice) {
+					frappe.msgprint(__("Sales Invoice could not be created."));
+					return;
+				} else {
+					frappe.set_route(
+						"Form",
+						"Sales Invoice",
+						data.sales_invoice,
+					);
+				}
 			},
 		});
 	},
@@ -407,9 +395,6 @@ function sync_items_with_sales_order(
 				) {
 					frm.add_child(child_table_field, {
 						[item_field]: so_item.item_code,
-						qty: so_item.qty,
-						rate: so_item.rate,
-						amount: so_item.amount,
 					});
 				}
 			});

--- a/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.json
+++ b/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.json
@@ -52,6 +52,7 @@
   "saved_filters",
   "section_break_cqdf",
   "beneficiaries",
+  "entries_created",
   "connections_tab"
  ],
  "fields": [
@@ -135,13 +136,15 @@
    "fieldname": "project",
    "fieldtype": "Link",
    "label": "Project",
-   "options": "Project"
+   "options": "Project",
+   "search_index": 1
   },
   {
    "fieldname": "cost_center",
    "fieldtype": "Link",
    "label": "Cost Center",
-   "options": "Cost Center"
+   "options": "Cost Center",
+   "search_index": 1
   },
   {
    "fieldname": "allocation_items_section",
@@ -219,7 +222,8 @@
    "fieldname": "sales_order",
    "fieldtype": "Link",
    "label": "Sales Order",
-   "options": "Sales Order"
+   "options": "Sales Order",
+   "search_index": 1
   },
   {
    "fieldname": "section_break_kvsp",
@@ -326,6 +330,14 @@
    "fieldtype": "Link",
    "label": "Account Paid To",
    "options": "Account"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "entries_created",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Entries created"
   }
  ],
  "grid_page_length": 50,
@@ -348,7 +360,7 @@
    "link_fieldname": "donation_disbursement_entry"
   }
  ],
- "modified": "2026-01-28 13:03:27.348398",
+ "modified": "2026-02-02 07:45:36.096038",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Donation Disbursement Entry",

--- a/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.py
+++ b/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.py
@@ -18,7 +18,39 @@ class DonationDisbursementEntry(Document):
         for row in self.beneficiaries or []:
             row.amount = (row.qty or 0) * (row.rate or 0)
             total_amount += row.amount or 0
+
+        if self.sales_order:
+            sales_order = frappe.get_doc("Sales Order", self.sales_order)
+
+            item_codes = [item.item_code for item in (self.items or [])]
+            
+            if item_codes:
+                order_items = [
+                    {
+                        "item_code": so_item.item_code,
+                        "item_name": so_item.item_name,
+                        "qty": so_item.qty,
+                        "rate": so_item.rate,
+                        "amount": so_item.amount,
+                        "uom": so_item.uom,
+                    }
+                    for so_item in sales_order.items
+                    if so_item.item_code in item_codes
+                ]
+                
+                order_items_total = sum(item.get("amount", 0) for item in order_items)
+                if total_amount > order_items_total:
+                    frappe.throw(
+                        _("Total disbursement amount {0} exceeds Sales Order total {1}").format(
+                            total_amount, order_items_total
+                        )
+                    )
+            
         self.total_amount = total_amount
+
+    def before_submit(self):
+        if not self.beneficiaries:
+            frappe.throw(_("At least one beneficiary must be allocated before submitting."))
 
     @frappe.whitelist()
     def get_beneficiaries(self, advanced_filters=None):
@@ -194,9 +226,8 @@ class DonationDisbursementEntry(Document):
             )
             payment_entry.insert(ignore_permissions=True)
             row.payment_entry = payment_entry.name
-
+        self.entries_created = True
         self.save()
-        self.submit()
         frappe.msgprint(f"Payment Entries created for {len(self.beneficiaries)} beneficiaries")
 
     @frappe.whitelist()
@@ -245,60 +276,71 @@ class DonationDisbursementEntry(Document):
             for row in rows:
                 row.stock_entry = stock_entry.name
 
+        self.entries_created = True
         self.save()
-        self.submit()
         frappe.msgprint(f"Stock Entries created for {len(beneficiaries_by_beneficiary)} beneficiary(ies)")
 
     @frappe.whitelist()
-    def get_invoice_details(self):
+    def create_sales_invoice(self):
         customer = frappe.get_value("Donor", self.donor, "customer") if self.donor else None
+
+        data = {
+            "items": {},
+            "customer": customer,
+            "currency": None,
+            "total_amount": 0
+        }
+
         if self.allocation_type == "Cash":
             payment_entries = frappe.get_all(
                 "Payment Entry",
-                filters={"donation_disbursement_entry": self.name, "docstatus": 1},
-                fields=["name", "paid_amount as amount", "paid_from_account_currency"],
+                filters={
+                    "donation_disbursement_entry": self.name,
+                    "docstatus": 1
+                },
+                fields=["paid_amount as amount", "paid_from_account_currency"],
             )
-            total_amount = sum(pe.amount for pe in payment_entries)
-            currency = payment_entries[0].paid_from_account_currency if payment_entries else None
 
-            items_totals = {}
+            data["total_amount"] = sum(pe.amount for pe in payment_entries)
+            data["currency"] = payment_entries[0].paid_from_account_currency if payment_entries else None
+
             if self.items:
                 item = self.items[0]
-                items_totals[item.item_code] = {
+                data["items"][item.item_code] = {
                     "item_code": item.item_code,
                     "item_name": frappe.get_value("Item", item.item_code, "item_name"),
-                    "amount": total_amount,
+                    "amount": data["total_amount"],
                     "qty": 1,
                     "uom": item.uom,
-                    "rate": total_amount
+                    "rate": data["total_amount"],
                 }
 
-            return {
-                "total_amount": total_amount,
-                "currency": currency,
-                "items": items_totals,
-                "customer": customer,
-            }
-        
         elif self.allocation_type == "Items":
             stock_entries = frappe.get_all(
                 "Stock Entry",
-                filters={"donation_disbursement_entry": self.name, "docstatus": 1},
+                filters={
+                    "donation_disbursement_entry": self.name,
+                    "docstatus": 1
+                },
                 fields=["name", "total_outgoing_value as amount"],
             )
-            total_amount = sum(se.amount for se in stock_entries)
 
-            items_totals = {}
+            data["total_amount"] = sum(se.amount for se in stock_entries)
+
             for se in stock_entries:
                 items = frappe.get_all(
                     "Stock Entry Detail",
                     filters={"parent": se.name},
-                    fields=["item_code", "item_name", "amount", "qty", "basic_rate", "uom", "s_warehouse as warehouse"],
+                    fields=[
+                        "item_code", "item_name", "amount", "qty",
+                        "basic_rate", "uom", "s_warehouse as warehouse"
+                    ],
                 )
+
                 for item in items:
                     code = item.item_code
-                    if code not in items_totals:
-                        items_totals[code] = {
+                    if code not in data["items"]:
+                        data["items"][code] = {
                             "item_code": code,
                             "item_name": item.item_name,
                             "uom": item.uom,
@@ -308,12 +350,37 @@ class DonationDisbursementEntry(Document):
                             "rate": item.basic_rate,
                         }
 
-                    items_totals[code]["amount"] += item.amount
-                    items_totals[code]["qty"] += item.qty
-                    items_totals[code]["rate"] = item.basic_rate  
+                    data["items"][code]["amount"] += item.amount
+                    data["items"][code]["qty"] += item.qty
+                    data["items"][code]["rate"] = item.basic_rate
 
-            return {
-                "total_amount": total_amount,
-                "items": items_totals,
-                "customer": customer,
-            }
+        else:
+            frappe.throw("Invalid Allocation Type")
+
+        si = frappe.new_doc("Sales Invoice")
+
+        si.flags.ignore_mandatory = True
+        si.flags.ignore_validate = True
+        si.flags.ignore_permissions = True
+        si.flags.ignore_links = True
+
+        si.customer = data["customer"]
+        si.currency = data["currency"]
+        si.donation_disbursement_entry = self.name
+
+        for item in data["items"].values():
+            row = si.append("items", {})
+            row.item_code = item["item_code"]
+            row.item_name = item["item_name"]
+            row.qty = item["qty"]
+            row.rate = item["rate"]
+            row.amount = item["amount"]
+            row.uom = item["uom"]
+            if item.get("warehouse"):
+                row.warehouse = item["warehouse"]
+
+        si.insert(ignore_permissions=True)
+
+        return {
+            "sales_invoice": si.name
+        }

--- a/changemakers/frappe_changemakers/overrides/sales_order.js
+++ b/changemakers/frappe_changemakers/overrides/sales_order.js
@@ -1,0 +1,36 @@
+frappe.ui.form.on("Sales Order", {
+	refresh: function (frm) {
+		if (!frm.is_new()) {
+			frm.add_custom_button(
+				__("Disbursement Entry"),
+				function () {
+					frappe.model.with_doctype(
+						"Donation Disbursement Entry",
+						function () {
+							const ddtMeta = frappe.get_meta(
+								"Donation Disbursement Entry",
+							);
+							let values = { sales_order: frm.doc.name };
+							ddtMeta.fields.forEach(function (field) {
+								if (
+									frm.doc.hasOwnProperty(field.fieldname) &&
+									field.fieldtype !== "Table" &&
+									!field.no_copy
+								) {
+									values[field.fieldname] =
+										frm.doc[field.fieldname];
+								}
+							});
+							frappe.new_doc(
+								"Donation Disbursement Entry",
+								values,
+							);
+						},
+					);
+				},
+				__("Create"),
+			);
+			frm.page.set_inner_btn_group_as_primary(__("Create"));
+		}
+	},
+});

--- a/changemakers/hooks.py
+++ b/changemakers/hooks.py
@@ -84,6 +84,7 @@ website_route_rules = [
 # include js in doctype views
 doctype_js = {
     "Stock Entry": "frappe_changemakers/overrides/stock_entry.js",
+    "Sales Order": "frappe_changemakers/overrides/sales_order.js",
     "Project": "frappe_changemakers/overrides/project.js",
     "Payment Entry": "frappe_changemakers/overrides/payment_entry.js",
 }


### PR DESCRIPTION
Enhance the disbursement workflow with budget validation, server-side invoice generation, and safeguards against duplicate document creation.

- Add `entries_created` flag and allow-on-submit links for traceability.
- Move Sales Invoice assembly to server and return name for UI routing.
- Implement validation: prevent submission without beneficiaries.
- Implement budget check: ensure disbursement total <= Sales Order total.
- Refactor logic to create but not auto-submit Payment/Stock entries.
- Update UI to conditionally show 'Create Sales Invoice' button.
- Register Sales Order overrides in the client-side controller.