### PR TITLE
feat(permissions): grant Non Profit Manager access to disbursement workflows

### DIFF
--- a/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.json
+++ b/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.json
@@ -900,7 +900,7 @@
    "link_fieldname": "beneficiary"
   }
  ],
- "modified": "2026-01-28 08:24:27.054702",
+ "modified": "2026-02-02 08:19:17.122953",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Beneficiary",
@@ -1014,6 +1014,18 @@
    "report": 1,
    "role": "Learning Centre POC",
    "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.json
+++ b/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.json
@@ -360,7 +360,7 @@
    "link_fieldname": "donation_disbursement_entry"
   }
  ],
- "modified": "2026-02-02 07:45:36.096038",
+ "modified": "2026-02-02 08:18:14.982435",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Donation Disbursement Entry",
@@ -377,6 +377,20 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "submit": 1,
    "write": 1


### PR DESCRIPTION
Update DocPerms and metadata to allow the Non Profit Manager role to fully oversee beneficiary records and donation disbursements.

- Grant full CRUD (Create, Read, Update, Delete) permissions to
  Non Profit Manager for Beneficiaries and Disbursement Entries.
- Add Submit and Cancel authorities for disbursement workflows.
- Enable auxiliary rights: Email, Export, Print, Report, and Share.