### PR TITLE
feat(donation-disbursement): enforce UoM and account validation

### DIFF
--- a/changemakers/frappe_changemakers/doctype/beneficiary_disbursement_entry_item/beneficiary_disbursement_entry_item.json
+++ b/changemakers/frappe_changemakers/doctype/beneficiary_disbursement_entry_item/beneficiary_disbursement_entry_item.json
@@ -84,7 +84,8 @@
    "fieldname": "uom",
    "fieldtype": "Link",
    "label": "UoM",
-   "options": "UOM"
+   "options": "UOM",
+   "reqd": 1
   },
   {
    "fieldname": "rate",
@@ -128,7 +129,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-27 15:43:31.156197",
+ "modified": "2026-02-02 09:07:35.367448",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Beneficiary Disbursement Entry Item",

--- a/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.js
+++ b/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.js
@@ -395,6 +395,7 @@ function sync_items_with_sales_order(
 				) {
 					frm.add_child(child_table_field, {
 						[item_field]: so_item.item_code,
+						uom: so_item.uom,
 					});
 				}
 			});

--- a/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.json
+++ b/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.json
@@ -314,11 +314,11 @@
    "label": "Accounts"
   },
   {
-   "depends_on": "eval: doc.allocation_type == \"Cash\"",
    "fieldname": "paid_from",
    "fieldtype": "Link",
    "label": "Account Paid From",
-   "options": "Account"
+   "options": "Account",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_xmyu",
@@ -329,6 +329,7 @@
    "fieldname": "paid_to",
    "fieldtype": "Link",
    "label": "Account Paid To",
+   "mandatory_depends_on": "eval: doc.allocation_type == \"Cash\"",
    "options": "Account"
   },
   {
@@ -360,7 +361,7 @@
    "link_fieldname": "donation_disbursement_entry"
   }
  ],
- "modified": "2026-02-02 08:18:14.982435",
+ "modified": "2026-02-02 09:11:58.633905",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Donation Disbursement Entry",

--- a/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.py
+++ b/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.py
@@ -360,12 +360,10 @@ class DonationDisbursementEntry(Document):
         si = frappe.new_doc("Sales Invoice")
 
         si.flags.ignore_mandatory = True
-        si.flags.ignore_validate = True
         si.flags.ignore_permissions = True
         si.flags.ignore_links = True
 
         si.customer = data["customer"]
-        si.currency = data["currency"]
         si.donation_disbursement_entry = self.name
 
         for item in data["items"].values():
@@ -373,9 +371,12 @@ class DonationDisbursementEntry(Document):
             row.item_code = item["item_code"]
             row.item_name = item["item_name"]
             row.qty = item["qty"]
+            row.stock_qty = item["qty"]
             row.rate = item["rate"]
             row.amount = item["amount"]
             row.uom = item["uom"]
+            row.stock_uom = item["uom"]
+            row.conversion_factor = 1.0
             if item.get("warehouse"):
                 row.warehouse = item["warehouse"]
 


### PR DESCRIPTION
Enhance data integrity and stock accounting by making critical fields mandatory and refining the invoice generation logic.

- Require 'UOM' and 'Cash Account' for relevant allocation types.
- Propagate UOM from source orders into disbursement child rows.
- Include `stock_qty`, `stock_uom`, and `conversion_factor` in Sales Invoices.
- Remove explicit currency overrides to leverage system defaults.
- Restore standard validation by removing `ignore_validate` flags.
- Ensure accurate stock valuation by syncing units with child items.