### PR TITLE
feat(config): enhance permissions and workspace for Non Profit Manager

### DIFF
--- a/changemakers/frappe_changemakers/doctype/case/case.json
+++ b/changemakers/frappe_changemakers/doctype/case/case.json
@@ -1,649 +1,662 @@
 {
-  "actions": [],
-  "allow_import": 1,
-  "autoname": "autoincrement",
-  "creation": "2022-12-23 16:33:03.271918",
-  "default_view": "List",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": [
-    "section_break_zguo",
-    "title",
-    "description",
-    "start_date",
-    "end_date",
-    "column_break_fkgv",
-    "type",
-    "status",
-    "priority",
-    "amended_from",
-    "project",
-    "program",
-    "location_section",
-    "is_beneficiary_in_shelter_home",
-    "section_break_grcq",
-    "state",
-    "district",
-    "zone",
-    "ward",
-    "habitation",
-    "shelter_home",
-    "beneficiary_details_section",
-    "is_beneficiary_traced",
-    "beneficiary",
-    "full_name",
-    "column_break_jywm",
-    "gender",
-    "age",
-    "contact_number",
-    "updates_section",
-    "medical_update",
-    "food_update",
-    "entitlement",
-    "legal_update",
-    "column_break_vjme",
-    "shelter_update",
-    "admitted_to_shelter",
-    "other_update",
-    "payment_details_section",
-    "payment_details",
-    "total_amount",
-    "follow_up_details_section",
-    "family_meeting_outcome",
-    "followups",
-    "section_break_seoz",
-    "created_by",
-    "section_break_yuho",
-    "bottom_save_button",
-    "column_break_qfjk",
-    "assessment_tab",
-    "housing_assessed",
-    "column_break_qzux",
-    "food_assessed",
-    "section_break_gyac",
-    "housing_type",
-    "no_of_rooms",
-    "home_ownedrented",
-    "column_break_goqn",
-    "washroom_present",
-    "water_accessible",
-    "electricity_accessible",
-    "lighting_accessible",
-    "section_break_ksqi",
-    "how_many_weeks_do_the_rations_last",
-    "reason_for_run_out",
-    "comments",
-    "column_break_uxrn",
-    "food_item_to_be_changed",
-    "items_that_run_out_first",
-    "food_item_to_be_included",
-    "food_item_to_be_increased"
-  ],
-  "fields": [
-    {
-      "fieldname": "title",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Title",
-      "reqd": 1
-    },
-    {
-      "fieldname": "type",
-      "fieldtype": "Link",
-      "label": "Type",
-      "options": "Case Type",
-      "reqd": 1
-    },
-    {
-      "fieldname": "description",
-      "fieldtype": "Small Text",
-      "label": "Description"
-    },
-    {
-      "default": "0",
-      "fieldname": "is_beneficiary_in_shelter_home",
-      "fieldtype": "Check",
-      "label": "Is the beneficiary in shelter home?"
-    },
-    {
-      "depends_on": "eval:doc.is_beneficiary_in_shelter_home === 1",
-      "fieldname": "shelter_home",
-      "fieldtype": "Link",
-      "label": "Shelter Home",
-      "options": "Shelter Home"
-    },
-    {
-      "fetch_from": "shelter_home.state",
-      "fetch_if_empty": 1,
-      "fieldname": "state",
-      "fieldtype": "Link",
-      "label": "State",
-      "options": "State"
-    },
-    {
-      "fetch_from": "shelter_home.district",
-      "fetch_if_empty": 1,
-      "fieldname": "district",
-      "fieldtype": "Link",
-      "label": "City/District",
-      "options": "District"
-    },
-    {
-      "fetch_from": "shelter_home.zone",
-      "fetch_if_empty": 1,
-      "fieldname": "zone",
-      "fieldtype": "Link",
-      "label": "Zone/Block",
-      "options": "Zone"
-    },
-    {
-      "fetch_from": "shelter_home.ward",
-      "fetch_if_empty": 1,
-      "fieldname": "ward",
-      "fieldtype": "Link",
-      "label": "Ward/GP",
-      "options": "Ward"
-    },
-    {
-      "fetch_from": "shelter_home.",
-      "fieldname": "habitation",
-      "fieldtype": "Link",
-      "label": "Hotspot Name/Habitation",
-      "options": "Habitation"
-    },
-    {
-      "fieldname": "amended_from",
-      "fieldtype": "Link",
-      "label": "Amended From",
-      "no_copy": 1,
-      "options": "Case",
-      "print_hide": 1,
-      "read_only": 1
-    },
-    {
-      "default": "Medium",
-      "fieldname": "priority",
-      "fieldtype": "Select",
-      "label": "Priority",
-      "options": "Urgent\nHigh\nMedium\nLow"
-    },
-    {
-      "default": "New",
-      "fieldname": "status",
-      "fieldtype": "Select",
-      "in_list_view": 1,
-      "in_preview": 1,
-      "in_standard_filter": 1,
-      "label": "Status",
-      "options": "New\nIn Follow Up\nSpam\nUntraced\nClosed",
-      "reqd": 1
-    },
-    {
-      "fieldname": "beneficiary",
-      "fieldtype": "Link",
-      "label": "Beneficiary",
-      "mandatory_depends_on": "eval:doc.is_beneficiary_traced==true",
-      "options": "Beneficiary"
-    },
-    {
-      "fetch_from": "beneficiary.age",
-      "fieldname": "age",
-      "fieldtype": "Int",
-      "label": "Age",
-      "read_only": 1
-    },
-    {
-      "fetch_from": "beneficiary.gender",
-      "fieldname": "gender",
-      "fieldtype": "Link",
-      "label": "Gender",
-      "options": "Gender",
-      "read_only": 1
-    },
-    {
-      "fetch_from": "beneficiary.phone_number",
-      "fieldname": "contact_number",
-      "fieldtype": "Data",
-      "label": "Contact Number",
-      "options": "Phone",
-      "read_only": 1
-    },
-    {
-      "default": "0",
-      "fieldname": "is_beneficiary_traced",
-      "fieldtype": "Check",
-      "label": "Is Beneficiary Traced?"
-    },
-    {
-      "fieldname": "location_section",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Location"
-    },
-    {
-      "fieldname": "section_break_zguo",
-      "fieldtype": "Section Break",
-      "label": "Case Details"
-    },
-    {
-      "fieldname": "column_break_fkgv",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "beneficiary_details_section",
-      "fieldtype": "Section Break",
-      "label": "Beneficiary Details"
-    },
-    {
-      "fieldname": "column_break_jywm",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "follow_up_details_section",
-      "fieldtype": "Section Break",
-      "label": "Follow Up Details"
-    },
-    {
-      "fieldname": "followups",
-      "fieldtype": "Table",
-      "label": "Followups",
-      "options": "Case Followup"
-    },
-    {
-      "depends_on": "eval:doc.type=='Identified a Family'",
-      "fieldname": "family_meeting_outcome",
-      "fieldtype": "Select",
-      "label": "Family Meeting Outcome",
-      "options": "Meeting went well and the Beneficiary returned to home\nMeeting went well but the Beneficiary didn\u2019t go home\nFamily members did not come\nBeneficiary didn\u2019t go for the meeting\nMismatch"
-    },
-    {
-      "fieldname": "updates_section",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Updates"
-    },
-    {
-      "depends_on": "eval:doc.type==\"Shelter\" && doc.is_beneficiary_traced==true",
-      "fieldname": "shelter_update",
-      "fieldtype": "Select",
-      "label": "Shelter Update",
-      "options": "\nNot Willing To Come\nAdmitted"
-    },
-    {
-      "depends_on": "eval:doc.type==\"Shelter\" && doc.is_beneficiary_traced==true && doc.shelter_update==\"Admitted\"",
-      "fieldname": "admitted_to_shelter",
-      "fieldtype": "Link",
-      "label": "Admitted To Shelter",
-      "mandatory_depends_on": "eval:doc.shelter_update==\"Admitted\"",
-      "options": "Shelter Home"
-    },
-    {
-      "fieldname": "column_break_vjme",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "medical_update",
-      "fieldtype": "Select",
-      "label": "Medical Update",
-      "options": "\nHospitalised\nTreatment Done\nReferred To Other Organisation"
-    },
-    {
-      "fieldname": "food_update",
-      "fieldtype": "Select",
-      "label": "Food Update",
-      "options": "\nResolved and reported\nFood escalation"
-    },
-    {
-      "fieldname": "entitlement",
-      "fieldtype": "Select",
-      "label": "Entitlement Update",
-      "options": "\nIn Process\nResolved"
-    },
-    {
-      "fieldname": "legal_update",
-      "fieldtype": "Select",
-      "label": "Legal Update",
-      "options": "\nComplaint registered\nReferred to agency"
-    },
-    {
-      "fieldname": "other_update",
-      "fieldtype": "Small Text",
-      "label": "Other Update"
-    },
-    {
-      "fieldname": "section_break_yuho",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "bottom_save_button",
-      "fieldtype": "Button",
-      "label": "Save"
-    },
-    {
-      "fieldname": "column_break_qfjk",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "section_break_seoz",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "created_by",
-      "fieldtype": "Data",
-      "label": "Created By",
-      "read_only": 1
-    },
-    {
-      "fieldname": "section_break_grcq",
-      "fieldtype": "Section Break",
-      "hidden": 1
-    },
-    {
-      "fetch_from": "beneficiary.full_name",
-      "fieldname": "full_name",
-      "fieldtype": "Data",
-      "label": "Name"
-    },
-    {
-      "fieldname": "payment_details_section",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Payment Details"
-    },
-    {
-      "fieldname": "payment_details",
-      "fieldtype": "Table",
-      "label": "Payment Details",
-      "options": "Payment Details"
-    },
-    {
-      "fieldname": "total_amount",
-      "fieldtype": "Currency",
-      "label": "Total Amount",
-      "non_negative": 1,
-      "read_only": 1
-    },
-    {
-      "fieldname": "assessment_tab",
-      "fieldtype": "Tab Break",
-      "label": "Assessment"
-    },
-    {
-      "default": "0",
-      "fieldname": "housing_assessed",
-      "fieldtype": "Check",
-      "label": "Housing has been assessed"
-    },
-    {
-      "default": "0",
-      "fieldname": "food_assessed",
-      "fieldtype": "Check",
-      "label": "Food  has been assessed"
-    },
-    {
-      "depends_on": "eval: doc.food_assessed == 1",
-      "fieldname": "section_break_ksqi",
-      "fieldtype": "Section Break",
-      "label": "Food"
-    },
-    {
-      "fieldname": "how_many_weeks_do_the_rations_last",
-      "fieldtype": "Int",
-      "label": "How many weeks do the rations last?"
-    },
-    {
-      "fieldname": "column_break_uxrn",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "food_item_to_be_increased",
-      "fieldtype": "Table MultiSelect",
-      "label": "Food Item to be increased",
-      "options": "Assessment Item"
-    },
-    {
-      "fieldname": "reason_for_run_out",
-      "fieldtype": "Small Text",
-      "label": "Reason for run out"
-    },
-    {
-      "fieldname": "comments",
-      "fieldtype": "Small Text",
-      "label": "Comments"
-    },
-    {
-      "fieldname": "food_item_to_be_changed",
-      "fieldtype": "Table MultiSelect",
-      "label": "Food Item to be changed",
-      "options": "Assessment Item"
-    },
-    {
-      "fieldname": "items_that_run_out_first",
-      "fieldtype": "Table MultiSelect",
-      "label": "Items that run out first",
-      "options": "Assessment Item"
-    },
-    {
-      "fieldname": "food_item_to_be_included",
-      "fieldtype": "Table MultiSelect",
-      "label": "Food Item to be included",
-      "options": "Assessment Item"
-    },
-    {
-      "depends_on": "eval: doc.housing_assessed == 1",
-      "fieldname": "section_break_gyac",
-      "fieldtype": "Section Break",
-      "label": "Housing"
-    },
-    {
-      "fieldname": "housing_type",
-      "fieldtype": "Select",
-      "label": "Housing Type",
-      "options": "Permanent\nSemi Permanent\nOther"
-    },
-    {
-      "fieldname": "home_ownedrented",
-      "fieldtype": "Select",
-      "label": "Home Owned/Rented?",
-      "options": "Own home\nRented"
-    },
-    {
-      "fieldname": "column_break_goqn",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "no_of_rooms",
-      "fieldtype": "Int",
-      "label": "No. of Rooms"
-    },
-    {
-      "default": "0",
-      "fieldname": "washroom_present",
-      "fieldtype": "Check",
-      "label": "Washroom is present"
-    },
-    {
-      "default": "0",
-      "fieldname": "water_accessible",
-      "fieldtype": "Check",
-      "label": "Water is accessible"
-    },
-    {
-      "default": "0",
-      "fieldname": "electricity_accessible",
-      "fieldtype": "Check",
-      "label": "Electricity is accessible"
-    },
-    {
-      "default": "0",
-      "fieldname": "lighting_accessible",
-      "fieldtype": "Check",
-      "label": "Lighting is accessible"
-    },
-    {
-      "fieldname": "column_break_qzux",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "start_date",
-      "fieldtype": "Date",
-      "label": "Start Date"
-    },
-    {
-      "fieldname": "end_date",
-      "fieldtype": "Date",
-      "label": "End Date"
-    },
-    {
-      "fieldname": "project",
-      "fieldtype": "Link",
-      "label": "Project",
-      "options": "Project"
-    },
-    {
-      "fieldname": "program",
-      "fieldtype": "Link",
-      "label": "Program",
-      "options": "Program"
-    }
-  ],
-  "index_web_pages_for_search": 1,
-  "links": [],
-  "modified": "2025-06-19 12:25:39.091951",
-  "modified_by": "Administrator",
-  "module": "Frappe Changemakers",
-  "name": "Case",
-  "naming_rule": "Autoincrement",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "select": 1,
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Admin (Partner)",
-      "select": 1,
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Partner SMT",
-      "select": 1,
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Social Worker",
-      "select": 1,
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Program Manager",
-      "select": 1,
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Healthcare Team Member",
-      "select": 1,
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "SMT(NGO)-Field Co-ordinator",
-      "select": 1,
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Medical Co-ordinator",
-      "select": 1,
-      "share": 1,
-      "write": 1
-    }
-  ],
-  "row_format": "Dynamic",
-  "show_title_field_in_link": 1,
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [
-    {
-      "color": "Cyan",
-      "title": "New"
-    },
-    {
-      "color": "Yellow",
-      "title": "In Follow Up"
-    },
-    {
-      "color": "Green",
-      "title": "Closed"
-    },
-    {
-      "color": "Red",
-      "title": "Spam"
-    },
-    {
-      "color": "Orange",
-      "title": "Untraced"
-    }
-  ],
-  "title_field": "title",
-  "track_changes": 1,
-  "track_seen": 1,
-  "track_views": 1
+ "actions": [],
+ "allow_import": 1,
+ "autoname": "autoincrement",
+ "creation": "2022-12-23 16:33:03.271918",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_zguo",
+  "title",
+  "description",
+  "start_date",
+  "end_date",
+  "column_break_fkgv",
+  "type",
+  "status",
+  "priority",
+  "amended_from",
+  "project",
+  "program",
+  "location_section",
+  "is_beneficiary_in_shelter_home",
+  "section_break_grcq",
+  "state",
+  "district",
+  "zone",
+  "ward",
+  "habitation",
+  "shelter_home",
+  "beneficiary_details_section",
+  "is_beneficiary_traced",
+  "beneficiary",
+  "full_name",
+  "column_break_jywm",
+  "gender",
+  "age",
+  "contact_number",
+  "updates_section",
+  "medical_update",
+  "food_update",
+  "entitlement",
+  "legal_update",
+  "column_break_vjme",
+  "shelter_update",
+  "admitted_to_shelter",
+  "other_update",
+  "payment_details_section",
+  "payment_details",
+  "total_amount",
+  "follow_up_details_section",
+  "family_meeting_outcome",
+  "followups",
+  "section_break_seoz",
+  "created_by",
+  "section_break_yuho",
+  "bottom_save_button",
+  "column_break_qfjk",
+  "assessment_tab",
+  "housing_assessed",
+  "column_break_qzux",
+  "food_assessed",
+  "section_break_gyac",
+  "housing_type",
+  "no_of_rooms",
+  "home_ownedrented",
+  "column_break_goqn",
+  "washroom_present",
+  "water_accessible",
+  "electricity_accessible",
+  "lighting_accessible",
+  "section_break_ksqi",
+  "how_many_weeks_do_the_rations_last",
+  "reason_for_run_out",
+  "comments",
+  "column_break_uxrn",
+  "food_item_to_be_changed",
+  "items_that_run_out_first",
+  "food_item_to_be_included",
+  "food_item_to_be_increased"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1
+  },
+  {
+   "fieldname": "type",
+   "fieldtype": "Link",
+   "label": "Type",
+   "options": "Case Type",
+   "reqd": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_beneficiary_in_shelter_home",
+   "fieldtype": "Check",
+   "label": "Is the beneficiary in shelter home?"
+  },
+  {
+   "depends_on": "eval:doc.is_beneficiary_in_shelter_home === 1",
+   "fieldname": "shelter_home",
+   "fieldtype": "Link",
+   "label": "Shelter Home",
+   "options": "Shelter Home"
+  },
+  {
+   "fetch_from": "shelter_home.state",
+   "fetch_if_empty": 1,
+   "fieldname": "state",
+   "fieldtype": "Link",
+   "label": "State",
+   "options": "State"
+  },
+  {
+   "fetch_from": "shelter_home.district",
+   "fetch_if_empty": 1,
+   "fieldname": "district",
+   "fieldtype": "Link",
+   "label": "City/District",
+   "options": "District"
+  },
+  {
+   "fetch_from": "shelter_home.zone",
+   "fetch_if_empty": 1,
+   "fieldname": "zone",
+   "fieldtype": "Link",
+   "label": "Zone/Block",
+   "options": "Zone"
+  },
+  {
+   "fetch_from": "shelter_home.ward",
+   "fetch_if_empty": 1,
+   "fieldname": "ward",
+   "fieldtype": "Link",
+   "label": "Ward/GP",
+   "options": "Ward"
+  },
+  {
+   "fetch_from": "shelter_home.",
+   "fieldname": "habitation",
+   "fieldtype": "Link",
+   "label": "Hotspot Name/Habitation",
+   "options": "Habitation"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Case",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "default": "Medium",
+   "fieldname": "priority",
+   "fieldtype": "Select",
+   "label": "Priority",
+   "options": "Urgent\nHigh\nMedium\nLow"
+  },
+  {
+   "default": "New",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "New\nIn Follow Up\nSpam\nUntraced\nClosed",
+   "reqd": 1
+  },
+  {
+   "fieldname": "beneficiary",
+   "fieldtype": "Link",
+   "label": "Beneficiary",
+   "mandatory_depends_on": "eval:doc.is_beneficiary_traced==true",
+   "options": "Beneficiary"
+  },
+  {
+   "fetch_from": "beneficiary.age",
+   "fieldname": "age",
+   "fieldtype": "Int",
+   "label": "Age",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "beneficiary.gender",
+   "fieldname": "gender",
+   "fieldtype": "Link",
+   "label": "Gender",
+   "options": "Gender",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "beneficiary.phone_number",
+   "fieldname": "contact_number",
+   "fieldtype": "Data",
+   "label": "Contact Number",
+   "options": "Phone",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_beneficiary_traced",
+   "fieldtype": "Check",
+   "label": "Is Beneficiary Traced?"
+  },
+  {
+   "fieldname": "location_section",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Location"
+  },
+  {
+   "fieldname": "section_break_zguo",
+   "fieldtype": "Section Break",
+   "label": "Case Details"
+  },
+  {
+   "fieldname": "column_break_fkgv",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "beneficiary_details_section",
+   "fieldtype": "Section Break",
+   "label": "Beneficiary Details"
+  },
+  {
+   "fieldname": "column_break_jywm",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "follow_up_details_section",
+   "fieldtype": "Section Break",
+   "label": "Follow Up Details"
+  },
+  {
+   "fieldname": "followups",
+   "fieldtype": "Table",
+   "label": "Followups",
+   "options": "Case Followup"
+  },
+  {
+   "depends_on": "eval:doc.type=='Identified a Family'",
+   "fieldname": "family_meeting_outcome",
+   "fieldtype": "Select",
+   "label": "Family Meeting Outcome",
+   "options": "Meeting went well and the Beneficiary returned to home\nMeeting went well but the Beneficiary didn\u2019t go home\nFamily members did not come\nBeneficiary didn\u2019t go for the meeting\nMismatch"
+  },
+  {
+   "fieldname": "updates_section",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Updates"
+  },
+  {
+   "depends_on": "eval:doc.type==\"Shelter\" && doc.is_beneficiary_traced==true",
+   "fieldname": "shelter_update",
+   "fieldtype": "Select",
+   "label": "Shelter Update",
+   "options": "\nNot Willing To Come\nAdmitted"
+  },
+  {
+   "depends_on": "eval:doc.type==\"Shelter\" && doc.is_beneficiary_traced==true && doc.shelter_update==\"Admitted\"",
+   "fieldname": "admitted_to_shelter",
+   "fieldtype": "Link",
+   "label": "Admitted To Shelter",
+   "mandatory_depends_on": "eval:doc.shelter_update==\"Admitted\"",
+   "options": "Shelter Home"
+  },
+  {
+   "fieldname": "column_break_vjme",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "medical_update",
+   "fieldtype": "Select",
+   "label": "Medical Update",
+   "options": "\nHospitalised\nTreatment Done\nReferred To Other Organisation"
+  },
+  {
+   "fieldname": "food_update",
+   "fieldtype": "Select",
+   "label": "Food Update",
+   "options": "\nResolved and reported\nFood escalation"
+  },
+  {
+   "fieldname": "entitlement",
+   "fieldtype": "Select",
+   "label": "Entitlement Update",
+   "options": "\nIn Process\nResolved"
+  },
+  {
+   "fieldname": "legal_update",
+   "fieldtype": "Select",
+   "label": "Legal Update",
+   "options": "\nComplaint registered\nReferred to agency"
+  },
+  {
+   "fieldname": "other_update",
+   "fieldtype": "Small Text",
+   "label": "Other Update"
+  },
+  {
+   "fieldname": "section_break_yuho",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "bottom_save_button",
+   "fieldtype": "Button",
+   "label": "Save"
+  },
+  {
+   "fieldname": "column_break_qfjk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_seoz",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "created_by",
+   "fieldtype": "Data",
+   "label": "Created By",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_grcq",
+   "fieldtype": "Section Break",
+   "hidden": 1
+  },
+  {
+   "fetch_from": "beneficiary.full_name",
+   "fieldname": "full_name",
+   "fieldtype": "Data",
+   "label": "Name"
+  },
+  {
+   "fieldname": "payment_details_section",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Payment Details"
+  },
+  {
+   "fieldname": "payment_details",
+   "fieldtype": "Table",
+   "label": "Payment Details",
+   "options": "Payment Details"
+  },
+  {
+   "fieldname": "total_amount",
+   "fieldtype": "Currency",
+   "label": "Total Amount",
+   "non_negative": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "assessment_tab",
+   "fieldtype": "Tab Break",
+   "label": "Assessment"
+  },
+  {
+   "default": "0",
+   "fieldname": "housing_assessed",
+   "fieldtype": "Check",
+   "label": "Housing has been assessed"
+  },
+  {
+   "default": "0",
+   "fieldname": "food_assessed",
+   "fieldtype": "Check",
+   "label": "Food  has been assessed"
+  },
+  {
+   "depends_on": "eval: doc.food_assessed == 1",
+   "fieldname": "section_break_ksqi",
+   "fieldtype": "Section Break",
+   "label": "Food"
+  },
+  {
+   "fieldname": "how_many_weeks_do_the_rations_last",
+   "fieldtype": "Int",
+   "label": "How many weeks do the rations last?"
+  },
+  {
+   "fieldname": "column_break_uxrn",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "food_item_to_be_increased",
+   "fieldtype": "Table MultiSelect",
+   "label": "Food Item to be increased",
+   "options": "Assessment Item"
+  },
+  {
+   "fieldname": "reason_for_run_out",
+   "fieldtype": "Small Text",
+   "label": "Reason for run out"
+  },
+  {
+   "fieldname": "comments",
+   "fieldtype": "Small Text",
+   "label": "Comments"
+  },
+  {
+   "fieldname": "food_item_to_be_changed",
+   "fieldtype": "Table MultiSelect",
+   "label": "Food Item to be changed",
+   "options": "Assessment Item"
+  },
+  {
+   "fieldname": "items_that_run_out_first",
+   "fieldtype": "Table MultiSelect",
+   "label": "Items that run out first",
+   "options": "Assessment Item"
+  },
+  {
+   "fieldname": "food_item_to_be_included",
+   "fieldtype": "Table MultiSelect",
+   "label": "Food Item to be included",
+   "options": "Assessment Item"
+  },
+  {
+   "depends_on": "eval: doc.housing_assessed == 1",
+   "fieldname": "section_break_gyac",
+   "fieldtype": "Section Break",
+   "label": "Housing"
+  },
+  {
+   "fieldname": "housing_type",
+   "fieldtype": "Select",
+   "label": "Housing Type",
+   "options": "Permanent\nSemi Permanent\nOther"
+  },
+  {
+   "fieldname": "home_ownedrented",
+   "fieldtype": "Select",
+   "label": "Home Owned/Rented?",
+   "options": "Own home\nRented"
+  },
+  {
+   "fieldname": "column_break_goqn",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "no_of_rooms",
+   "fieldtype": "Int",
+   "label": "No. of Rooms"
+  },
+  {
+   "default": "0",
+   "fieldname": "washroom_present",
+   "fieldtype": "Check",
+   "label": "Washroom is present"
+  },
+  {
+   "default": "0",
+   "fieldname": "water_accessible",
+   "fieldtype": "Check",
+   "label": "Water is accessible"
+  },
+  {
+   "default": "0",
+   "fieldname": "electricity_accessible",
+   "fieldtype": "Check",
+   "label": "Electricity is accessible"
+  },
+  {
+   "default": "0",
+   "fieldname": "lighting_accessible",
+   "fieldtype": "Check",
+   "label": "Lighting is accessible"
+  },
+  {
+   "fieldname": "column_break_qzux",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "start_date",
+   "fieldtype": "Date",
+   "label": "Start Date"
+  },
+  {
+   "fieldname": "end_date",
+   "fieldtype": "Date",
+   "label": "End Date"
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
+  },
+  {
+   "fieldname": "program",
+   "fieldtype": "Link",
+   "label": "Program",
+   "options": "Program"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-02-02 09:27:23.954357",
+ "modified_by": "Administrator",
+ "module": "Frappe Changemakers",
+ "name": "Case",
+ "naming_rule": "Autoincrement",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Admin (Partner)",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Partner SMT",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Social Worker",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Program Manager",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Healthcare Team Member",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "SMT(NGO)-Field Co-ordinator",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Medical Co-ordinator",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "show_title_field_in_link": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [
+  {
+   "color": "Cyan",
+   "title": "New"
+  },
+  {
+   "color": "Yellow",
+   "title": "In Follow Up"
+  },
+  {
+   "color": "Green",
+   "title": "Closed"
+  },
+  {
+   "color": "Red",
+   "title": "Spam"
+  },
+  {
+   "color": "Orange",
+   "title": "Untraced"
+  }
+ ],
+ "title_field": "title",
+ "track_changes": 1,
+ "track_seen": 1,
+ "track_views": 1
 }

--- a/changemakers/frappe_changemakers/doctype/changemakers_settings/changemakers_settings.json
+++ b/changemakers/frappe_changemakers/doctype/changemakers_settings/changemakers_settings.json
@@ -106,7 +106,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-27 12:17:07.469740",
+ "modified": "2026-02-02 09:23:02.334975",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Changemakers Settings",
@@ -119,6 +119,16 @@
    "print": 1,
    "read": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/collector/collector.json
+++ b/changemakers/frappe_changemakers/doctype/collector/collector.json
@@ -46,11 +46,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-11 18:08:27.890316",
+ "modified": "2026-02-02 09:28:34.519770",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Collector",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -64,8 +64,21 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/recruitment_phase/recruitment_phase.json
+++ b/changemakers/frappe_changemakers/doctype/recruitment_phase/recruitment_phase.json
@@ -105,11 +105,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-05 14:26:33.023673",
+ "modified": "2026-02-02 09:28:50.928277",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Recruitment Phase",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -123,8 +123,21 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/workspace/changemakers/changemakers.json
+++ b/changemakers/frappe_changemakers/workspace/changemakers/changemakers.json
@@ -1,7 +1,7 @@
 {
  "app": "changemakers",
  "charts": [],
- "content": "[{\"id\":\"CecwNbV5Aq\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Frappe Changemakers</span>\",\"col\":12}},{\"id\":\"fP4on4W26W\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"asboRySoyS\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Your Shortcuts</span>\",\"col\":12}},{\"id\":\"JhoJIvxYwo\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Beneficiary\",\"col\":4}},{\"id\":\"pJjBJY4itE\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Donation Disbursement Entry\",\"col\":3}},{\"id\":\"H-e6U8hWgm\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Changemakers Settings\",\"col\":4}},{\"id\":\"7znHj1wPAe\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"j_2-NL3927\",\"type\":\"paragraph\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Reports &amp; Masters</span>\",\"col\":12}},{\"id\":\"674ks-aO5v\",\"type\":\"card\",\"data\":{\"card_name\":\"Masters\",\"col\":4}},{\"id\":\"7zD8pl7CLK\",\"type\":\"card\",\"data\":{\"card_name\":\" Programs & Education\",\"col\":4}},{\"id\":\"EeW5aA91EY\",\"type\":\"card\",\"data\":{\"card_name\":\"Reports\",\"col\":4}},{\"id\":\"eOReRO_Pc0\",\"type\":\"card\",\"data\":{\"card_name\":\" Impact & Metrics\",\"col\":4}},{\"id\":\"CebhoNopem\",\"type\":\"card\",\"data\":{\"card_name\":\"Donations & Contributions\",\"col\":4}},{\"id\":\"bah2NGZNN6\",\"type\":\"card\",\"data\":{\"card_name\":\"Configuration\",\"col\":4}},{\"id\":\"R_wvE3WP7g\",\"type\":\"card\",\"data\":{\"card_name\":\"Health & Medical\",\"col\":4}},{\"id\":\"MlRQ2-1l9o\",\"type\":\"spacer\",\"data\":{\"col\":12}}]",
+ "content": "[{\"id\":\"CecwNbV5Aq\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Frappe Changemakers</span>\",\"col\":12}},{\"id\":\"fP4on4W26W\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"asboRySoyS\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Your Shortcuts</span>\",\"col\":12}},{\"id\":\"JhoJIvxYwo\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Beneficiary\",\"col\":4}},{\"id\":\"pJjBJY4itE\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Donation Disbursement Entry\",\"col\":3}},{\"id\":\"H-e6U8hWgm\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Changemakers Settings\",\"col\":4}},{\"id\":\"7znHj1wPAe\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"j_2-NL3927\",\"type\":\"paragraph\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Reports &amp; Masters</span>\",\"col\":12}},{\"id\":\"674ks-aO5v\",\"type\":\"card\",\"data\":{\"card_name\":\"Masters\",\"col\":4}},{\"id\":\"CebhoNopem\",\"type\":\"card\",\"data\":{\"card_name\":\"Donations & Contributions\",\"col\":4}},{\"id\":\"bah2NGZNN6\",\"type\":\"card\",\"data\":{\"card_name\":\"Configuration\",\"col\":4}},{\"id\":\"7zD8pl7CLK\",\"type\":\"card\",\"data\":{\"card_name\":\" Programs & Education\",\"col\":4}},{\"id\":\"R_wvE3WP7g\",\"type\":\"card\",\"data\":{\"card_name\":\"Health & Medical\",\"col\":4}},{\"id\":\"eOReRO_Pc0\",\"type\":\"card\",\"data\":{\"card_name\":\" Impact & Metrics\",\"col\":4}},{\"id\":\"EeW5aA91EY\",\"type\":\"card\",\"data\":{\"card_name\":\"Reports\",\"col\":4}},{\"id\":\"MlRQ2-1l9o\",\"type\":\"spacer\",\"data\":{\"col\":12}}]",
  "creation": "2022-10-13 13:51:43.725589",
  "custom_blocks": [],
  "docstatus": 0,
@@ -361,7 +361,7 @@
    "hidden": 0,
    "is_query_report": 0,
    "label": "Donations & Contributions",
-   "link_count": 4,
+   "link_count": 6,
    "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"
@@ -405,9 +405,29 @@
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Sales Order",
+   "link_count": 0,
+   "link_to": "Sales Order",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Sales Invoice",
+   "link_count": 0,
+   "link_to": "Sales Invoice",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2026-01-28 11:37:50.150987",
+ "modified": "2026-02-02 09:25:51.048795",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Changemakers",


### PR DESCRIPTION
Update role permissions, naming rules, and workspace discoverability to support core non-profit management workflows.

- Grant full permissions to 'Non Profit Manager' for Settings, Collector,
  and Recruitment Phase.
- Update naming rules to 'Expression (old style)' for Collector and
  Recruitment Phase for consistent ID generation.
- Add Sales Order and Sales Invoice links to the 'Donations &
  Contributions' section of the workspace.
- Rebalance workspace link counts and refresh metadata/timestamps.
- Normalize row format and field ordering across modified DocTypes.