### PR TITLE
fix(donation-disbursement): support row-level mode of payment

### DIFF
--- a/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.py
+++ b/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.py
@@ -215,7 +215,7 @@ class DonationDisbursementEntry(Document):
                     "paid_to": self.paid_to,
                     "company": self.company,
                     "posting_date": today(),
-                    "mode_of_payment": self.mode_of_payment,
+                    "mode_of_payment": row.mode_of_payment,
                     "cost_center": self.cost_center,
                     "project": self.project,
                     "paid_amount": row.amount,


### PR DESCRIPTION
Refine Payment Entry generation to utilize the specific mode of payment defined in each beneficiary row instead of a global document value.

- Update server-side logic to pull `mode_of_payment` from child table rows.
- Enable support for multi-mode disbursements within a single entry.
- Prevent incorrect payment method assignment during batch processing.
- Ensure the generated Payment Entry reflects the specific financial instrument used for each beneficiary.