### PR TITLE
feat(non-profit): implement global RBAC overhaul and operations cleanup

### DIFF
--- a/changemakers/frappe_changemakers/doctype/awareness_camp_record/awareness_camp_record.json
+++ b/changemakers/frappe_changemakers/doctype/awareness_camp_record/awareness_camp_record.json
@@ -169,11 +169,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-22 14:10:00.297548",
+ "modified": "2026-02-03 15:53:06.077553",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Awareness Camp Record",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -242,8 +242,21 @@
    "select": 1,
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/beneficiary_donor_assignment/beneficiary_donor_assignment.json
+++ b/changemakers/frappe_changemakers/doctype/beneficiary_donor_assignment/beneficiary_donor_assignment.json
@@ -7,8 +7,11 @@
  "engine": "InnoDB",
  "field_order": [
   "donor",
+  "beneficiary_no",
+  "project",
   "column_break_lpms",
-  "beneficiary_no"
+  "entitlement_currency",
+  "entitlement_amount"
  ],
  "fields": [
   {
@@ -34,13 +37,38 @@
    "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Beneficiary No"
+  },
+  {
+   "fieldname": "entitlement_currency",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Entitlement Currency",
+   "options": "Currency"
+  },
+  {
+   "fieldname": "entitlement_amount",
+   "fieldtype": "Currency",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Entitlement Amount"
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-27 13:25:55.706378",
+ "modified": "2026-02-03 16:07:22.594156",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Beneficiary Donor Assignment",

--- a/changemakers/frappe_changemakers/doctype/beneficiary_status/beneficiary_status.json
+++ b/changemakers/frappe_changemakers/doctype/beneficiary_status/beneficiary_status.json
@@ -21,7 +21,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-15 11:54:08.778824",
+ "modified": "2026-02-03 15:55:53.780979",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Beneficiary Status",
@@ -37,6 +37,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/beneficiary_type/beneficiary_type.json
+++ b/changemakers/frappe_changemakers/doctype/beneficiary_type/beneficiary_type.json
@@ -17,7 +17,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-16 13:58:43.306132",
+ "modified": "2026-02-03 15:42:10.491003",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Beneficiary Type",
@@ -33,6 +33,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/care_centre/care_centre.json
+++ b/changemakers/frappe_changemakers/doctype/care_centre/care_centre.json
@@ -61,7 +61,7 @@
    "link_fieldname": "facility_name"
   }
  ],
- "modified": "2023-10-27 17:41:48.472208",
+ "modified": "2026-02-03 15:52:08.521826",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Care Centre",
@@ -163,8 +163,21 @@
    "role": "Medical Co-ordinator",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/care_centre_admission/care_centre_admission.json
+++ b/changemakers/frappe_changemakers/doctype/care_centre_admission/care_centre_admission.json
@@ -220,7 +220,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-05 14:36:09.303010",
+ "modified": "2026-02-03 15:52:22.314811",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Care Centre Admission",
@@ -298,8 +298,21 @@
    "role": "SMT(NGO)-Field Co-ordinator",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/case_type/case_type.json
+++ b/changemakers/frappe_changemakers/doctype/case_type/case_type.json
@@ -25,7 +25,7 @@
   }
  ],
  "links": [],
- "modified": "2023-06-20 14:39:24.732781",
+ "modified": "2026-02-03 15:51:00.369793",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Case Type",
@@ -89,8 +89,21 @@
    "select": 1,
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/changemakers_user_profile/changemakers_user_profile.json
+++ b/changemakers/frappe_changemakers/doctype/changemakers_user_profile/changemakers_user_profile.json
@@ -45,7 +45,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-03 20:07:26.758191",
+ "modified": "2026-02-03 15:47:37.017669",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Changemakers User Profile",
@@ -62,9 +62,22 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/chronic_illness_type/chronic_illness_type.json
+++ b/changemakers/frappe_changemakers/doctype/chronic_illness_type/chronic_illness_type.json
@@ -19,7 +19,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-03 16:12:17.036109",
+ "modified": "2026-02-03 15:45:43.196663",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Chronic Illness Type",
@@ -137,9 +137,22 @@
    "role": "Learning Centre POC",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/county/county.json
+++ b/changemakers/frappe_changemakers/doctype/county/county.json
@@ -34,14 +34,9 @@
    "group": "County",
    "link_doctype": "Sub County",
    "link_fieldname": "county"
-  },
-  {
-   "group": "Ward",
-   "link_doctype": "Ward",
-   "link_fieldname": "county"
   }
  ],
- "modified": "2026-01-07 12:37:25.122989",
+ "modified": "2026-02-03 15:58:27.202445",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "County",
@@ -57,6 +52,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/daily_visit_update/daily_visit_update.json
+++ b/changemakers/frappe_changemakers/doctype/daily_visit_update/daily_visit_update.json
@@ -52,11 +52,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-05 17:11:41.703890",
+ "modified": "2026-02-03 15:51:24.682845",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Daily Visit Update",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -120,8 +120,21 @@
    "select": 1,
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/disability_condition/disability_condition.json
+++ b/changemakers/frappe_changemakers/doctype/disability_condition/disability_condition.json
@@ -21,7 +21,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-03-01 12:25:32.010136",
+ "modified": "2026-02-03 15:43:32.327400",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Disability Condition",
@@ -52,8 +52,21 @@
    "select": 1,
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/district/district.json
+++ b/changemakers/frappe_changemakers/doctype/district/district.json
@@ -31,7 +31,7 @@
    "link_fieldname": "district"
   }
  ],
- "modified": "2023-02-03 17:53:12.478454",
+ "modified": "2026-02-03 15:44:28.161490",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "District",
@@ -160,9 +160,22 @@
    "role": "All",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/donation_allocation/donation_allocation.json
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation/donation_allocation.json
@@ -218,7 +218,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-01-26 14:59:45.817464",
+ "modified": "2026-02-03 15:59:33.687290",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Donation Allocation",
@@ -236,6 +236,18 @@
    "role": "System Manager",
    "share": 1,
    "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
    "write": 1
   }
  ],

--- a/changemakers/frappe_changemakers/doctype/donation_allocation_criteria_type/donation_allocation_criteria_type.json
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation_criteria_type/donation_allocation_criteria_type.json
@@ -17,7 +17,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-15 12:02:31.415296",
+ "modified": "2026-02-03 15:59:05.674605",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Donation Allocation Criteria Type",
@@ -33,6 +33,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/donation_allocation_policy/donation_allocation_policy.json
+++ b/changemakers/frappe_changemakers/doctype/donation_allocation_policy/donation_allocation_policy.json
@@ -67,7 +67,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-15 14:59:08.511167",
+ "modified": "2026-02-03 15:59:19.006189",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Donation Allocation Policy",
@@ -83,6 +83,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.js
+++ b/changemakers/frappe_changemakers/doctype/donation_disbursement_entry/donation_disbursement_entry.js
@@ -8,9 +8,6 @@ frappe.ui.form.on("Donation Disbursement Entry", {
 	},
 
 	onload: function (frm) {
-		if (frm.doc.docstatus == 0 && !frm.is_new()) {
-			frm.trigger("render_custom_buttons");
-		}
 		if (!frm.doc.from_date) {
 			frm.set_value("from_date", frappe.datetime.nowdate());
 		}
@@ -49,6 +46,9 @@ frappe.ui.form.on("Donation Disbursement Entry", {
 	},
 
 	refresh: function (frm) {
+		if (frm.doc.docstatus == 0 && !frm.is_new()) {
+			frm.trigger("render_custom_buttons");
+		}
 		if (frm.is_dirty()) {
 			frm.page.set_primary_action(__("Save"), () => frm.save());
 		} else {
@@ -245,26 +245,30 @@ frappe.ui.form.on("Donation Disbursement Entry", {
 	},
 
 	render_custom_buttons: function (frm) {
-		const $wrapper = frm
-			.get_field("beneficiaries")
-			.$wrapper.find(".grid-heading-row");
-		$wrapper.find(".custom-table-actions").remove();
+		const grid_wrapper = frm.get_field("beneficiaries").$wrapper;
+
+		grid_wrapper.find(".custom-table-actions").remove();
+
 		const $btn_container = $(`
-            <div class="custom-table-actions" style="margin-bottom:10px;display:flex;gap:10px;">
-                <button class="btn btn-primary btn-sm btn-download-template">
-                    <i class="fa fa-download"></i> ${__("Download Template")}
-                </button>
-                <button class="btn btn-primary btn-sm btn-upload-list">
-                    <i class="fa fa-upload"></i> ${__("Upload List")}
-                </button>
-            </div>
-        `).prependTo(frm.get_field("beneficiaries").$wrapper);
+		<div class="custom-table-actions" style="margin-bottom:10px;display:flex;gap:10px;">
+			<button type="button" class="btn btn-primary btn-sm btn-download-template">
+				<i class="fa fa-download"></i> ${__("Download Template")}
+			</button>
+			<button type="button" class="btn btn-primary btn-sm btn-upload-list">
+				<i class="fa fa-upload"></i> ${__("Upload List")}
+			</button>
+		</div>
+	`).prependTo(grid_wrapper);
+
 		$btn_container
 			.find(".btn-download-template")
-			.click(() => frm.trigger("download_template_dialog"));
+			.off("click")
+			.on("click", () => frm.trigger("download_template_dialog"));
+
 		$btn_container
 			.find(".btn-upload-list")
-			.click(() => frm.trigger("upload_list"));
+			.off("click")
+			.on("click", () => frm.trigger("upload_list"));
 	},
 
 	download_template_dialog: function (frm) {

--- a/changemakers/frappe_changemakers/doctype/education_level/education_level.json
+++ b/changemakers/frappe_changemakers/doctype/education_level/education_level.json
@@ -19,7 +19,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-03 16:12:21.223977",
+ "modified": "2026-02-03 15:47:04.924235",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Education Level",
@@ -137,9 +137,22 @@
    "role": "Learning Centre POC",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/entitlement_request/entitlement_request.json
+++ b/changemakers/frappe_changemakers/doctype/entitlement_request/entitlement_request.json
@@ -90,11 +90,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-22 19:00:40.008085",
+ "modified": "2026-02-03 15:50:10.466675",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Entitlement Request",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -108,7 +108,6 @@
    "report": 1,
    "role": "System Manager",
    "select": 1,
-   "set_user_permissions": 1,
    "share": 1,
    "write": 1
   },
@@ -168,8 +167,21 @@
    "select": 1,
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [

--- a/changemakers/frappe_changemakers/doctype/entitlement_type/entitlement_type.json
+++ b/changemakers/frappe_changemakers/doctype/entitlement_type/entitlement_type.json
@@ -20,7 +20,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-03 21:11:15.793909",
+ "modified": "2026-02-03 15:43:10.932984",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Entitlement Type",
@@ -151,8 +151,21 @@
    "select": 1,
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/family_reintegration/family_reintegration.json
+++ b/changemakers/frappe_changemakers/doctype/family_reintegration/family_reintegration.json
@@ -149,7 +149,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-15 20:14:38.797269",
+ "modified": "2026-02-03 15:48:32.703116",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Family Reintegration",
@@ -235,8 +235,21 @@
    "select": 1,
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/changemakers/frappe_changemakers/doctype/food_distribution_record/food_distribution_record.json
+++ b/changemakers/frappe_changemakers/doctype/food_distribution_record/food_distribution_record.json
@@ -99,7 +99,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-02-15 20:16:35.596171",
+ "modified": "2026-02-03 15:48:45.918806",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Food Distribution Record",
@@ -184,9 +184,22 @@
    "role": "SMT(NGO)-Field Co-ordinator",
    "select": 1,
    "share": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/habitation/habitation.json
+++ b/changemakers/frappe_changemakers/doctype/habitation/habitation.json
@@ -18,7 +18,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-03 18:03:22.780768",
+ "modified": "2026-02-03 15:42:44.324037",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Habitation",
@@ -48,8 +48,21 @@
    "select": 1,
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/health_camp_record/health_camp_record.json
+++ b/changemakers/frappe_changemakers/doctype/health_camp_record/health_camp_record.json
@@ -210,11 +210,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-22 14:10:37.280810",
+ "modified": "2026-02-03 15:53:28.959529",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Health Camp Record",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -311,8 +311,21 @@
    "select": 1,
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/health_condition/health_condition.json
+++ b/changemakers/frappe_changemakers/doctype/health_condition/health_condition.json
@@ -22,7 +22,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-27 11:33:53.748804",
+ "modified": "2026-02-03 15:51:55.092084",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Health Condition",
@@ -88,9 +88,22 @@
    "role": "Program Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/healthcare_provider/healthcare_provider.json
+++ b/changemakers/frappe_changemakers/doctype/healthcare_provider/healthcare_provider.json
@@ -18,7 +18,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-03 21:01:07.076820",
+ "modified": "2026-02-03 15:47:51.891418",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Healthcare Provider",
@@ -47,9 +47,22 @@
    "role": "All",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/hospitalisation_record/hospitalisation_record.json
+++ b/changemakers/frappe_changemakers/doctype/hospitalisation_record/hospitalisation_record.json
@@ -110,11 +110,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-02 14:59:44.591875",
+ "modified": "2026-02-03 15:53:48.362046",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Hospitalisation Record",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -195,8 +195,21 @@
    "role": "Medical Co-ordinator",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/impact_measurement/impact_measurement.json
+++ b/changemakers/frappe_changemakers/doctype/impact_measurement/impact_measurement.json
@@ -152,7 +152,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-06 14:01:57.805659",
+ "modified": "2026-02-03 15:54:36.778145",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Impact Measurement",
@@ -169,8 +169,21 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/income_source_type/income_source_type.json
+++ b/changemakers/frappe_changemakers/doctype/income_source_type/income_source_type.json
@@ -19,7 +19,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-12-27 12:28:46.053626",
+ "modified": "2026-02-03 15:45:12.894820",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Income Source Type",
@@ -37,8 +37,21 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/key_result_area/key_result_area.json
+++ b/changemakers/frappe_changemakers/doctype/key_result_area/key_result_area.json
@@ -27,7 +27,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-23 13:25:40.946354",
+ "modified": "2026-02-03 15:56:21.102025",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Key Result Area",
@@ -43,6 +43,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/languages_known/languages_known.json
+++ b/changemakers/frappe_changemakers/doctype/languages_known/languages_known.json
@@ -22,7 +22,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-07-13 00:33:45.657027",
+ "modified": "2026-02-03 15:51:13.020669",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Languages Known",
@@ -40,9 +40,22 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/learning_centre/learning_centre.json
+++ b/changemakers/frappe_changemakers/doctype/learning_centre/learning_centre.json
@@ -157,7 +157,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-17 14:42:33.920761",
+ "modified": "2026-02-03 15:56:07.617869",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Learning Centre",
@@ -209,6 +209,18 @@
    "role": "Program Manager",
    "select": 1,
    "share": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "row_format": "Dynamic",

--- a/changemakers/frappe_changemakers/doctype/organisation/organisation.json
+++ b/changemakers/frappe_changemakers/doctype/organisation/organisation.json
@@ -26,7 +26,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-12-29 07:41:06.091618",
+ "modified": "2026-02-03 15:45:25.975111",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Organisation",
@@ -44,9 +44,22 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/partner_type/partner_type.json
+++ b/changemakers/frappe_changemakers/doctype/partner_type/partner_type.json
@@ -21,7 +21,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-30 09:46:45.691484",
+ "modified": "2026-02-03 15:57:06.641224",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Partner Type",
@@ -37,6 +37,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/payment_type/payment_type.json
+++ b/changemakers/frappe_changemakers/doctype/payment_type/payment_type.json
@@ -19,11 +19,10 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-17 09:20:27.707412",
+ "modified": "2026-02-03 15:51:42.593160",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Payment Type",
- "name_case": "Title Case",
  "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
@@ -38,8 +37,21 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/project_level/project_level.json
+++ b/changemakers/frappe_changemakers/doctype/project_level/project_level.json
@@ -28,7 +28,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-30 09:30:42.890071",
+ "modified": "2026-02-03 15:56:46.611659",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Project Level",
@@ -44,6 +44,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/religion/religion.json
+++ b/changemakers/frappe_changemakers/doctype/religion/religion.json
@@ -19,7 +19,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-03 16:12:18.894833",
+ "modified": "2026-02-03 15:43:52.058055",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Religion",
@@ -137,9 +137,22 @@
    "role": "Learning Centre POC",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/rescue/rescue.json
+++ b/changemakers/frappe_changemakers/doctype/rescue/rescue.json
@@ -283,7 +283,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-22 14:07:10.457125",
+ "modified": "2026-02-03 15:52:41.881693",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Rescue",
@@ -359,8 +359,21 @@
    "select": 1,
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/sdg/sdg.json
+++ b/changemakers/frappe_changemakers/doctype/sdg/sdg.json
@@ -37,7 +37,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-06 13:44:08.304649",
+ "modified": "2026-02-03 15:54:08.948846",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "SDG",
@@ -55,8 +55,21 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "number,title",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/changemakers/frappe_changemakers/doctype/shelter_home/shelter_home.json
+++ b/changemakers/frappe_changemakers/doctype/shelter_home/shelter_home.json
@@ -322,7 +322,7 @@
    "link_fieldname": "shelter_home"
   }
  ],
- "modified": "2023-02-28 13:58:28.101112",
+ "modified": "2026-02-03 15:50:30.270816",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Shelter Home",
@@ -382,8 +382,21 @@
    "role": "SMT(NGO)-Field Co-ordinator",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/shelter_home_admission_criterion/shelter_home_admission_criterion.json
+++ b/changemakers/frappe_changemakers/doctype/shelter_home_admission_criterion/shelter_home_admission_criterion.json
@@ -19,7 +19,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-17 20:12:46.224975",
+ "modified": "2026-02-03 15:49:33.039269",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Shelter Home Admission Criterion",
@@ -37,8 +37,21 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/shelter_home_admission_record/shelter_home_admission_record.json
+++ b/changemakers/frappe_changemakers/doctype/shelter_home_admission_record/shelter_home_admission_record.json
@@ -37,11 +37,11 @@
    "link_fieldname": "admission_record"
   }
  ],
- "modified": "2023-02-03 16:12:17.517519",
+ "modified": "2026-02-03 15:46:49.722741",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Shelter Home Admission Record",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -68,16 +68,6 @@
    "write": 1
   },
   {
-   "create": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Partner SMT",
-   "share": 1
-  },
-  {
    "email": 1,
    "export": 1,
    "print": 1,
@@ -86,17 +76,6 @@
    "role": "Social Worker",
    "select": 1,
    "share": 1
-  },
-  {
-   "create": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Admin (Partner)",
-   "share": 1,
-   "write": 1
   },
   {
    "email": 1,
@@ -120,16 +99,6 @@
    "share": 1
   },
   {
-   "email": 1,
-   "export": 1,
-   "if_owner": 1,
-   "print": 1,
-   "report": 1,
-   "role": "Partner SMT",
-   "share": 1,
-   "write": 1
-  },
-  {
    "create": 1,
    "email": 1,
    "export": 1,
@@ -150,9 +119,22 @@
    "role": "SMT(NGO)-Field Co-ordinator",
    "select": 1,
    "share": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/shelter_home_exit_record/shelter_home_exit_record.json
+++ b/changemakers/frappe_changemakers/doctype/shelter_home_exit_record/shelter_home_exit_record.json
@@ -33,11 +33,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-15 20:06:29.524948",
+ "modified": "2026-02-03 15:48:09.664381",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Shelter Home Exit Record",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -94,16 +94,6 @@
    "share": 1
   },
   {
-   "email": 1,
-   "export": 1,
-   "if_owner": 1,
-   "print": 1,
-   "report": 1,
-   "role": "Partner SMT",
-   "share": 1,
-   "write": 1
-  },
-  {
    "create": 1,
    "email": 1,
    "export": 1,
@@ -124,9 +114,22 @@
    "role": "SMT(NGO)-Field Co-ordinator",
    "select": 1,
    "share": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/shelter_home_service_record/shelter_home_service_record.json
+++ b/changemakers/frappe_changemakers/doctype/shelter_home_service_record/shelter_home_service_record.json
@@ -59,7 +59,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-28 14:02:37.980644",
+ "modified": "2026-02-03 15:50:46.383519",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Shelter Home Service Record",
@@ -118,8 +118,21 @@
    "role": "SMT(NGO)-Field Co-ordinator",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/changemakers/frappe_changemakers/doctype/shelter_home_support_type/shelter_home_support_type.json
+++ b/changemakers/frappe_changemakers/doctype/shelter_home_support_type/shelter_home_support_type.json
@@ -19,7 +19,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-17 20:20:01.680185",
+ "modified": "2026-02-03 15:49:54.723330",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Shelter Home Support Type",
@@ -37,8 +37,21 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/shelter_home_type/shelter_home_type.json
+++ b/changemakers/frappe_changemakers/doctype/shelter_home_type/shelter_home_type.json
@@ -19,7 +19,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-17 19:48:40.415242",
+ "modified": "2026-02-03 15:49:06.471863",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Shelter Home Type",
@@ -48,8 +48,21 @@
    "role": "All",
    "select": 1,
    "share": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/state/state.json
+++ b/changemakers/frappe_changemakers/doctype/state/state.json
@@ -36,7 +36,7 @@
    "link_fieldname": "state"
   }
  ],
- "modified": "2026-01-28 07:16:02.907474",
+ "modified": "2026-02-03 15:44:05.803978",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "State",
@@ -152,6 +152,18 @@
    "read": 1,
    "report": 1,
    "role": "Learning Centre POC",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/strategic_focus/strategic_focus.json
+++ b/changemakers/frappe_changemakers/doctype/strategic_focus/strategic_focus.json
@@ -29,7 +29,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-30 09:28:23.558389",
+ "modified": "2026-02-03 15:56:35.304256",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Strategic Focus",
@@ -45,6 +45,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/sub_county/sub_county.json
+++ b/changemakers/frappe_changemakers/doctype/sub_county/sub_county.json
@@ -35,7 +35,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-07 12:34:32.784407",
+ "modified": "2026-02-03 15:57:38.751562",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Sub County",
@@ -51,6 +51,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/thematic_area/thematic_area.json
+++ b/changemakers/frappe_changemakers/doctype/thematic_area/thematic_area.json
@@ -18,7 +18,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-17 15:43:06.840392",
+ "modified": "2026-02-03 15:55:40.729797",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Thematic Area",
@@ -36,8 +36,21 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/changemakers/frappe_changemakers/doctype/ward/ward.json
+++ b/changemakers/frappe_changemakers/doctype/ward/ward.json
@@ -28,7 +28,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-14 13:09:23.447017",
+ "modified": "2026-02-03 15:58:47.509313",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Ward",
@@ -144,6 +144,18 @@
    "read": 1,
    "report": 1,
    "role": "Learning Centre POC",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
    "share": 1,
    "write": 1
   }

--- a/changemakers/frappe_changemakers/doctype/zone/zone.json
+++ b/changemakers/frappe_changemakers/doctype/zone/zone.json
@@ -32,7 +32,7 @@
    "link_fieldname": "zone"
   }
  ],
- "modified": "2023-01-16 11:52:20.873853",
+ "modified": "2026-02-03 15:44:42.431564",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Zone",
@@ -150,9 +150,22 @@
    "role": "Learning Centre POC",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
Comprehensive update to standardize the 'Non Profit Manager' role across core DocTypes and enhance field operational logic.

- RBAC: Add 'Non Profit Manager' permissions to all core master data
  and operational DocTypes (Awareness Camps, Care Centres, SDGs, etc.).
- Beneficiary Management: Add project-linked entitlement fields
  (amount/currency) to Donor Assignments and update status permissions.
- UX/Logic: Refactor 'Donation Disbursement' client script for stable
  grid actions and improve naming rule labels across camp/health records.
- Cleanup: Remove deprecated properties (name_case), unused geographic groups (Ward in County), and normalize row_format to 'Dynamic'.