### PR TITLE
fix(dependencies): add frappe dependency for bench tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ build-backend = "flit_core.buildapi"
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0"
+
 [tool.ruff]
 line-length = 110
 target-version = "py310"


### PR DESCRIPTION
This pull request introduces a new section for managing Frappe dependencies in the `pyproject.toml` file. This helps clarify and separate framework dependencies from other development dependencies.

Dependency management:

* Added a `[tool.bench.frappe-dependencies]` section specifying `frappe >=15.0.0` to cleanly declare Frappe as a required dependency.