### PR TITLE
chore(deps): restrict Frappe dependency to version 16.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "flit_core.buildapi"
 # package_name = "~=1.1.0"
 
 [tool.bench.frappe-dependencies]
-frappe = ">=15.0.0"
+frappe = ">=16.0.0,<17.0.0"
 
 [tool.ruff]
 line-length = 110


### PR DESCRIPTION
Define explicit version constraints for the Frappe framework to ensure compatibility and prevent installation of breaking future releases.

- Add 'frappe >= 16.0.0, < 17.0.0' to project dependencies.
- Improve dependency resolution for bench-managed installations.
- Align project metadata with Frappe 16.x API stability.
- Prevent accidental upgrades to incompatible major versions.